### PR TITLE
More cleanup and concept-ification

### DIFF
--- a/include/pushmi/executor.h
+++ b/include/pushmi/executor.h
@@ -73,7 +73,7 @@ public:
     // ask whether T'& is convertible to T. That brings us right back to this
     // constructor. Constraint recursion!
    static_assert(TimeSenderTo<W, single<Other, E>>);
-   if constexpr ((bool)TimeSenderTo<W, single<Other, E>>) {
+   if constexpr((bool)TimeSenderTo<W, single<Other, E>>) {
       pobj_ = std::addressof(w);
       vptr_ = detail::any_time_executor_ref_vtable_v<E, TP, Other, Wrapped>();
    }

--- a/include/pushmi/flow_single.h
+++ b/include/pushmi/flow_single.h
@@ -279,9 +279,7 @@ class flow_single<>
     : public flow_single<ignoreVF, abortEF, ignoreDF, ignoreStpF, ignoreStrtF> {
 };
 
-using archetype_flow_single = flow_single<>;
-
-flow_single()->archetype_flow_single;
+flow_single()->flow_single<>;
 
 template <class VF>
     requires !Receiver<VF> && !detail::is_v<VF, on_error> &&

--- a/include/pushmi/none.h
+++ b/include/pushmi/none.h
@@ -20,9 +20,8 @@ class none<E> {
     return sizeof(Wrapped) <= sizeof(data::buffer_) &&
         std::is_nothrow_move_constructible_v<Wrapped>;
   }
-  enum struct op { destroy, move };
   struct vtable {
-    void (*op_)(op, data&, data*) = +[](op, data&, data*) {};
+    void (*op_)(data&, data*) = +[](data&, data*) {};
     void (*done_)(data&) = +[](data&) {};
     void (*error_)(data&, E) noexcept = +[](data&, E) noexcept {
       std::terminate();
@@ -31,13 +30,10 @@ class none<E> {
   } const* vptr_ = &vtable::noop_;
   template <class Wrapped, bool = insitu<Wrapped>()>
   static constexpr vtable const vtable_v = {
-      +[](op o, data& src, data* dst) {
-        switch (o) {
-          case op::move:
-            dst->pobj_ = std::exchange(src.pobj_, nullptr);
-          case op::destroy:
-            delete static_cast<Wrapped const*>(src.pobj_);
-        }
+      +[](data& src, data* dst) {
+        if (dst)
+          dst->pobj_ = std::exchange(src.pobj_, nullptr);
+        delete static_cast<Wrapped const*>(src.pobj_);
       },
       +[](data& src) { ::pushmi::set_done(*static_cast<Wrapped*>(src.pobj_)); },
       +[](data& src, E e) noexcept {
@@ -52,7 +48,7 @@ public:
 
   none() = default;
   none(none&& that) noexcept : none() {
-    that.vptr_->op_(op::move, that.data_, &data_);
+    that.vptr_->op_(that.data_, &data_);
     std::swap(that.vptr_, vptr_);
   }
   template <class Wrapped>
@@ -65,7 +61,7 @@ public:
     vptr_ = &vtable_v<Wrapped>;
   }
   ~none() {
-    vptr_->op_(op::destroy, data_, nullptr);
+    vptr_->op_(data_, nullptr);
   }
   none& operator=(none&& that) noexcept {
     this->~none();
@@ -93,14 +89,11 @@ constexpr typename none<E>::vtable const none<E>::vtable_v;
 template <class E>
 template <class Wrapped>
 constexpr typename none<E>::vtable const none<E>::vtable_v<Wrapped, true> = {
-    +[](op o, data& src, data* dst) {
-      switch (o) {
-        case op::move:
-          new (dst->buffer_)
-              Wrapped(std::move(*static_cast<Wrapped*>((void*)src.buffer_)));
-        case op::destroy:
-          static_cast<Wrapped const*>((void*)src.buffer_)->~Wrapped();
-      }
+    +[](data& src, data* dst) {
+      if (dst)
+        new (dst->buffer_)
+            Wrapped(std::move(*static_cast<Wrapped*>((void*)src.buffer_)));
+      static_cast<Wrapped const*>((void*)src.buffer_)->~Wrapped();
     },
     +[](data& src) {
       ::pushmi::set_done(*static_cast<Wrapped*>((void*)src.buffer_));
@@ -108,18 +101,18 @@ constexpr typename none<E>::vtable const none<E>::vtable_v<Wrapped, true> = {
     +[](data& src, E e) noexcept {::pushmi::set_error(
         *static_cast<Wrapped*>((void*)src.buffer_),
         std::move(e));
-}
-}
-;
+    }
+};
 
 template <class EF, class DF>
-requires Invocable<DF&> && !detail::is_v<EF, on_value> && !detail::is_v<EF, single>
+  requires Invocable<DF&>
 class none<EF, DF> {
+  static_assert(!detail::is_v<EF, on_value> && !detail::is_v<EF, single>);
   bool done_ = false;
-  EF ef_;
-  DF df_;
+  EF ef_{};
+  DF df_{};
 
- public:
+public:
   using receiver_category = none_tag;
 
   // static_assert(
@@ -137,27 +130,32 @@ class none<EF, DF> {
   template <class E>
     requires Invocable<EF&, E>
   void error(E e) noexcept {
-    static_assert(NothrowInvocable<EF&, E>, "error function must be noexcept");
-    if (done_) {return;}
-    done_ = true;
-    ef_(e);
+    static_assert(
+        noexcept(ef_(std::move(e))),
+        "error function must be noexcept");
+    if (!done_) {
+      done_ = true;
+      ef_(std::move(e));
+    }
   }
   void done() {
-    if (done_) {return;}
-    done_ = true;
-    df_();
+    if (!done_) {
+      done_ = true;
+      df_();
+    }
   }
 };
 
-template <Receiver Data, class DEF, class DDF>
-requires Invocable<DDF&, Data&> && !detail::is_v<DEF, on_value> && !detail::is_v<Data, single>
+template <Receiver<none_tag> Data, class DEF, class DDF>
+  requires Invocable<DDF&, Data&>
 class none<Data, DEF, DDF> {
   bool done_ = false;
-  Data data_;
-  DEF ef_;
-  DDF df_;
-
- public:
+  Data data_{};
+  DEF ef_{};
+  DDF df_{};
+  static_assert(!detail::is_v<DEF, on_value>);
+  static_assert(!detail::is_v<Data, single>);
+public:
   using receiver_category = none_tag;
 
   // static_assert(
@@ -168,71 +166,59 @@ class none<Data, DEF, DDF> {
   constexpr none(Data d, DDF df)
       : done_(false), data_(std::move(d)), ef_(), df_(std::move(df)) {}
   constexpr none(Data d, DEF ef, DDF df = DDF{})
-      : done_(false), data_(std::move(d)), ef_(std::move(ef)), df_(std::move(df)) {}
+      : done_(false), data_(std::move(d)), ef_(std::move(ef)),
+        df_(std::move(df)) {}
   template <class E>
-  requires Invocable<DEF&, Data&, E> void error(E e) noexcept {
+    requires Invocable<DEF&, Data&, E>
+  void error(E e) noexcept {
     static_assert(
-        NothrowInvocable<DEF&, Data&, E>, "error function must be noexcept");
-    if (done_) {return;}
-    done_ = true;
-    ef_(data_, e);
+        noexcept(ef_(data_, std::move(e))), "error function must be noexcept");
+    if (!done_) {
+      done_ = true;
+      ef_(data_, std::move(e));
+    }
   }
   void done() {
-    if (done_) {return;}
-    done_ = true;
-    df_(data_);
+    if (!done_) {
+      done_ = true;
+      df_(data_);
+    }
   }
 };
 
-template <> class none<> : public none<abortEF, ignoreDF> {};
+template <>
+class none<>
+    : public none<abortEF, ignoreDF> {
+};
 
-using archetype_none = none<>;
-
-none()->archetype_none;
+none() -> none<>;
 
 template <class EF>
-requires !Receiver<EF> &&
-!detail::is_v<EF, single> &&
-!detail::is_v<EF, on_value> &&
-!detail::is_v<EF, on_done>
-none(EF)->none<EF, ignoreDF>;
+none(EF) -> none<EF, ignoreDF>;
 
 template <class DF>
-requires !Receiver<DF> &&
-!detail::is_v<DF, on_value> &&
-!detail::is_v<DF, single>
-none(on_done<DF>)->none<abortEF, on_done<DF>>;
-
-template <class E, class Wrapped>
-requires NoneReceiver<Wrapped, E> &&
-!detail::is_v<E, on_value> &&
-!detail::is_v<Wrapped, single>
-none(Wrapped)->none<E>;
+  requires Invocable<DF&>
+none(DF)->none<abortEF, DF>;
 
 template <class EF, class DF>
-requires Invocable<DF&> none(EF, DF)->none<EF, DF>;
+  requires Invocable<DF&>
+none(EF, DF)->none<EF, DF>;
 
-template <Receiver Data>
-requires !detail::is_v<Data, on_value> &&
-!detail::is_v<Data, single>
-none(Data)->none<Data, passDEF, passDDF>;
+template <Receiver<none_tag> Data>
+  requires !Receiver<Data, single_tag>
+none(Data) -> none<Data, passDEF, passDDF>;
 
-template <Receiver Data, class DEF>
-requires !detail::is_v<DEF, on_done> &&
-!detail::is_v<Data, on_value> &&
-!detail::is_v<Data, single>
-none(Data, DEF)->none<Data, DEF, passDDF>;
+template <Receiver<none_tag> Data, class DEF>
+  requires !Receiver<Data, single_tag>
+none(Data, DEF) -> none<Data, DEF, passDDF>;
 
-template <Receiver Data, class DDF>
-requires !detail::is_v<Data, on_value> &&
-!detail::is_v<Data, single>
-none(Data, on_done<DDF>)->none<Data, passDEF, on_done<DDF>>;
+template <Receiver<none_tag> Data, class DDF>
+  requires Invocable<DDF&, Data&> && !Receiver<Data, single_tag>
+none(Data, DDF) -> none<Data, passDEF, DDF>;
 
-template <Receiver Data, class DEF, class DDF>
-requires Invocable<DDF&, Data&> &&
-!detail::is_v<Data, on_value> &&
-!detail::is_v<Data, single>
-none(Data, DEF, DDF)->none<Data, DEF, DDF>;
+template <Receiver<none_tag> Data, class DEF, class DDF>
+  requires !Receiver<Data, single_tag>
+none(Data, DEF, DDF) -> none<Data, DEF, DDF>;
 
 template <class E = std::exception_ptr>
 using any_none = none<E>;
@@ -251,12 +237,12 @@ using any_none = none<E>;
 //   return none<E>{std::move(w)};
 // }
 
-template <SenderTo<std::promise<void>, none_tag> S>
-std::future<void> future_from(S sender) {
+template <SenderTo<std::promise<void>, none_tag> Out>
+std::future<void> future_from(Out out) {
   std::promise<void> p;
   auto result = p.get_future();
-  submit(sender, std::move(p));
+  submit(out, std::move(p));
   return result;
 }
 
-} // namespace values
+} // namespace pushmi

--- a/include/pushmi/o/on.h
+++ b/include/pushmi/o/on.h
@@ -22,7 +22,7 @@ struct on_fn {
 template <class ExecutorFactory>
 auto on_fn::operator()(ExecutorFactory ef) const {
   return [ef = std::move(ef)]<class In>(In in) {
-    return ::pushmi::detail::deferred_from<In, archetype_single>(
+    return ::pushmi::detail::deferred_from<In, single<>>(
       std::move(in),
       ::pushmi::detail::submit_transform_out<In>(
         [ef]<class Out>(In& in, Out out) {

--- a/include/pushmi/o/transform.h
+++ b/include/pushmi/o/transform.h
@@ -17,19 +17,20 @@ namespace operators {
 namespace detail {
 
 struct transform_fn {
-template <class... FN>
-auto operator()(FN... fn) const;
+  template <class... FN>
+  auto operator()(FN... fn) const;
 };
+
 template <class... FN>
 auto transform_fn::operator()(FN... fn) const {
   auto f = overload{std::move(fn)...};
   return [f = std::move(f)]<class In>(In in) {
     // copy 'f' to allow multiple calls to connect to multiple 'in'
-    return ::pushmi::detail::deferred_from<In, archetype_single>(
+    return ::pushmi::detail::deferred_from<In, single<>>(
       std::move(in),
       ::pushmi::detail::submit_transform_out<In>(
         [f]<class Out>(Out out) {
-          return ::pushmi::detail::out_from<In>(
+          return ::pushmi::detail::out_from_fn<In>()(
             std::move(out),
             // copy 'f' to allow multiple calls to submit
             on_value{

--- a/include/pushmi/piping.h
+++ b/include/pushmi/piping.h
@@ -4,15 +4,17 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-template <class In, class Operator>
-auto operator|(In&& in, Operator op) -> decltype(op(std::forward<In>(in))) {
-  return op(std::forward<In>(in));
+#include "traits.h"
+
+template <class In, pushmi::Invocable<In> Op>
+decltype(auto) operator|(In&& in, Op op) {
+  return op((In&&) in);
 }
 
 namespace pushmi {
 
 template<class T, class... FN>
-auto pipe(T t, FN... fn) {
+auto pipe(T t, FN... fn) -> decltype((t | ... | fn)) {
   return (t | ... | fn);
 }
 

--- a/include/pushmi/single.h
+++ b/include/pushmi/single.h
@@ -4,15 +4,16 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <future>
 #include "none.h"
 
 namespace pushmi {
 
 namespace detail {
 
-template<class data, class op, class V, class E>
+template<class data, class V, class E>
 struct single_vtable {
-  void (*op_)(op, data&, data*) = +[](op, data&, data*) {};
+  void (*op_)(data&, data*) = +[](data&, data*) {};
   void (*done_)(data&) = +[](data&) {};
   void (*error_)(data&, E) noexcept = +[](data&, E) noexcept {
     std::terminate();
@@ -22,19 +23,16 @@ struct single_vtable {
   static constexpr single_vtable const noop_ = {};
 };
 
-template <class data, class op, class V, class E, class Wrapped, bool insitu>
+template <class data, class V, class E, class Wrapped, bool insitu>
 struct single_vtable_v;
 
-template <class data, class op, class V, class E, class Wrapped>
-struct single_vtable_v<data, op, V, E, Wrapped, false> {
-  static constexpr single_vtable<data, op, V, E> const vtable_v = {
-      +[](op o, data& src, data* dst) {
-        switch (o) {
-          case op::move:
-            dst->pobj_ = std::exchange(src.pobj_, nullptr);
-          case op::destroy:
-            delete static_cast<Wrapped const*>(src.pobj_);
-        }
+template <class data, class V, class E, class Wrapped>
+struct single_vtable_v<data, V, E, Wrapped, false> {
+  static constexpr single_vtable<data, V, E> const vtable_v = {
+      +[](data& src, data* dst) {
+        if (dst)
+          dst->pobj_ = std::exchange(src.pobj_, nullptr);
+        delete static_cast<Wrapped const*>(src.pobj_);
       },
       +[](data& src) { ::pushmi::set_done(*static_cast<Wrapped*>(src.pobj_)); },
       +[](data& src, E e) noexcept {
@@ -49,17 +47,14 @@ struct single_vtable_v<data, op, V, E, Wrapped, false> {
   };
 };
 
-template <class data, class op, class V, class E, class Wrapped>
-struct single_vtable_v<data, op, V, E, Wrapped, true> {
-  static constexpr single_vtable<data, op, V, E> const vtable_v = {
-    +[](op o, data& src, data* dst) {
-       switch (o) {
-         case op::move:
-           new (dst->buffer_) Wrapped(
-               std::move(*static_cast<Wrapped*>((void*)src.buffer_)));
-         case op::destroy:
-           static_cast<Wrapped const*>((void*)src.buffer_)->~Wrapped();
-       }
+template <class data, class V, class E, class Wrapped>
+struct single_vtable_v<data, V, E, Wrapped, true> {
+  static constexpr single_vtable<data, V, E> const vtable_v = {
+    +[](data& src, data* dst) {
+       if (dst)
+         new (dst->buffer_) Wrapped(
+             std::move(*static_cast<Wrapped*>((void*)src.buffer_)));
+       static_cast<Wrapped const*>((void*)src.buffer_)->~Wrapped();
     },
     +[](data& src) {
       ::pushmi::set_done(*static_cast<Wrapped*>((void*)src.buffer_));
@@ -80,8 +75,8 @@ struct single_vtable_v<data, op, V, E, Wrapped, true> {
 
 // Class static definitions:
 
-template<class data, class op, class V, class E>
-constexpr single_vtable<data, op, V, E> const single_vtable<data, op, V, E>::noop_;
+template<class data, class V, class E>
+constexpr single_vtable<data, V, E> const single_vtable<data, V, E>::noop_;
 
 } // namespace detail
 
@@ -97,20 +92,20 @@ class single<V, E> {
     return sizeof(Wrapped) <= sizeof(data::buffer_) &&
         std::is_nothrow_move_constructible_v<Wrapped>;
   }
-  enum struct op { destroy, move };
-  using vtable = detail::single_vtable<data, op, V, E>;
+  using vtable = detail::single_vtable<data, V, E>;
   vtable const* vptr_ = &vtable::noop_;
+
+  template <class T, class U = std::decay_t<T>>
+  using wrapped_t =
+    std::enable_if_t<!std::is_same_v<U, single>, U>;
 public:
   using receiver_category = single_tag;
 
   single() = default;
   single(single&& that) noexcept : single() {
-    that.vptr_->op_(op::move, that.data_, &data_);
+    that.vptr_->op_(that.data_, &data_);
     std::swap(that.vptr_, vptr_);
   }
-  template <class T, class U = std::decay_t<T>>
-  using wrapped_t =
-    std::enable_if_t<!std::is_same_v<U, single>, U>;
   template <class Wrapped>
    requires SingleReceiver<wrapped_t<Wrapped>, V, E>
   explicit single(Wrapped obj) : single() {
@@ -124,10 +119,11 @@ public:
       new (data_.buffer_) Wrapped(std::move(obj));
     else
       data_.pobj_ = new Wrapped(std::move(obj));
-    vptr_ = &detail::single_vtable_v<data, op, V, E, Wrapped, insitu<Wrapped>()>::vtable_v;
+    vptr_ =
+      &detail::single_vtable_v<data, V, E, Wrapped, insitu<Wrapped>()>::vtable_v;
   }
   ~single() {
-    vptr_->op_(op::destroy, data_, nullptr);
+    vptr_->op_(data_, nullptr);
   }
   single& operator=(single&& that) noexcept {
     this->~single();
@@ -137,39 +133,41 @@ public:
   template<class T>
   requires ConvertibleTo<T&&, V&&>
   void value(T&& t) {
-    if (done_) {return;}
-    done_ = true;
-    vptr_->rvalue_(data_, (T&&) t);
+    if (!done_) {
+      done_ = true;
+      vptr_->rvalue_(data_, (T&&) t);
+    }
   }
   template<class T>
   requires ConvertibleTo<T&, V&>
   void value(T& t) {
-    if (done_) {return;}
-    done_ = true;
-    vptr_->lvalue_(data_, t);
+    if (!done_) {
+      done_ = true;
+      vptr_->lvalue_(data_, t);
+    }
   }
   void error(E e) noexcept {
-    if (done_) {return;}
-    done_ = true;
-    vptr_->error_(data_, std::move(e));
+    if (!done_) {
+      done_ = true;
+      vptr_->error_(data_, std::move(e));
+    }
   }
   void done() {
-    if (done_) {return;}
-    done_ = true;
-    vptr_->done_(data_);
+    if (!done_) {
+      done_ = true;
+      vptr_->done_(data_);
+    }
   }
 };
 
 
 template <class VF, class EF, class DF>
-requires Invocable<DF&> class single<VF, EF, DF> {
+  requires Invocable<DF&>
+class single<VF, EF, DF> {
   bool done_ = false;
-  VF vf_;
-  EF ef_;
-  DF df_;
-
- public:
-  using receiver_category = single_tag;
+  VF vf_{};
+  EF ef_{};
+  DF df_{};
 
   static_assert(
       !detail::is_v<VF, on_error>,
@@ -180,6 +178,9 @@ requires Invocable<DF&> class single<VF, EF, DF> {
   static_assert(NothrowInvocable<EF, std::exception_ptr>,
       "error function must be noexcept and support std::exception_ptr");
 
+ public:
+  using receiver_category = single_tag;
+
   single() = default;
   constexpr explicit single(VF vf) : single(std::move(vf), EF{}, DF{}) {}
   constexpr explicit single(EF ef) : single(VF{}, std::move(ef), DF{}) {}
@@ -187,37 +188,40 @@ requires Invocable<DF&> class single<VF, EF, DF> {
   constexpr single(EF ef, DF df)
       : done_(false), vf_(), ef_(std::move(ef)), df_(std::move(df)) {}
   constexpr single(VF vf, EF ef, DF df = DF{})
-      : done_(false), vf_(std::move(vf)), ef_(std::move(ef)), df_(std::move(df)) {}
+      : done_(false), vf_(std::move(vf)), ef_(std::move(ef)), df_(std::move(df))
+  {}
+
   template <class V>
-  requires Invocable<VF&, V> void value(V&& v) {
+  requires Invocable<VF&, V>
+  void value(V&& v) {
     if (done_) {return;}
     done_ = true;
     vf_((V&&) v);
   }
   template <class E>
-  requires Invocable<EF&, E> void error(E e) noexcept {
+  requires Invocable<EF&, E>
+  void error(E e) noexcept {
     static_assert(NothrowInvocable<EF&, E>, "error function must be noexcept");
-    if (done_) {return;}
-    done_ = true;
-    ef_(std::move(e));
+    if (!done_) {
+      done_ = true;
+      ef_(std::move(e));
+    }
   }
   void done() {
-    if (done_) {return;}
-    done_ = true;
-    df_();
+    if (!done_) {
+      done_ = true;
+      df_();
+    }
   }
 };
 
 template <Receiver Data, class DVF, class DEF, class DDF>
 requires Invocable<DDF&, Data&> class single<Data, DVF, DEF, DDF> {
   bool done_ = false;
-  Data data_;
-  DVF vf_;
-  DEF ef_;
-  DDF df_;
-
- public:
-  using receiver_category = single_tag;
+  Data data_{};
+  DVF vf_{};
+  DEF ef_{};
+  DDF df_{};
 
   static_assert(
       !detail::is_v<DVF, on_error>,
@@ -228,8 +232,9 @@ requires Invocable<DDF&, Data&> class single<Data, DVF, DEF, DDF> {
   static_assert(NothrowInvocable<DEF, Data&, std::exception_ptr>,
       "error function must be noexcept and support std::exception_ptr");
 
-  template<class... AN>
-  constexpr explicit single(std::tuple<AN...> t) : single(std::apply(construct<Data>{}, std::move(t)), DEF{}, DDF{}) {}
+ public:
+  using receiver_category = single_tag;
+
   constexpr explicit single(Data d)
       : single(std::move(d), DVF{}, DEF{}, DDF{}) {}
   constexpr single(Data d, DDF df)
@@ -238,24 +243,30 @@ requires Invocable<DDF&, Data&> class single<Data, DVF, DEF, DDF> {
       : done_(false), data_(std::move(d)), vf_(), ef_(ef), df_(df) {}
   constexpr single(Data d, DVF vf, DEF ef = DEF{}, DDF df = DDF{})
       : done_(false), data_(std::move(d)), vf_(vf), ef_(ef), df_(df) {}
+
   template <class V>
-  requires Invocable<DVF&, Data&, V> void value(V&& v) {
-    if (done_) {return;}
-    done_ = true;
-    vf_(data_, (V&&) v);
+  requires Invocable<DVF&, Data&, V>
+  void value(V&& v) {
+    if (!done_) {
+      done_ = true;
+      vf_(data_, (V&&) v);
+    }
   }
   template <class E>
-  requires Invocable<DEF&, Data&, E> void error(E e) noexcept {
+  requires Invocable<DEF&, Data&, E>
+  void error(E e) noexcept {
     static_assert(
         NothrowInvocable<DEF&, Data&, E>, "error function must be noexcept");
-    if (done_) {return;}
-    done_ = true;
-    ef_(data_, std::move(e));
+    if (!done_) {
+      done_ = true;
+      ef_(data_, std::move(e));
+    }
   }
   void done() {
-    if (done_) {return;}
-    done_ = true;
-    df_(data_);
+    if (!done_) {
+      done_ = true;
+      df_(data_);
+    }
   }
 };
 
@@ -264,70 +275,51 @@ class single<>
     : public single<ignoreVF, abortEF, ignoreDF> {
 };
 
-using archetype_single = single<>;
-
-single()->single<>;
-
-template <class... AN>
-single(std::tuple<AN...>) ->
-    single<decltype(single{std::declval<AN&&>()...}), passDVF, passDEF, passDDF>;
+single() -> single<>;
 
 template <class VF>
-    requires !Receiver<VF> && !detail::is_v<VF, on_error> &&
-    !detail::is_v<VF, on_done>
 single(VF) -> single<VF, abortEF, ignoreDF>;
 
 template <class... EFN>
 single(on_error<EFN...>) -> single<ignoreVF, on_error<EFN...>, ignoreDF>;
 
 template <class DF>
-single(on_done<DF>) -> single<ignoreVF, abortEF, on_done<DF>>;
-
-template <class V, class E, class Wrapped>
-  requires SingleReceiver<Wrapped, V, E>
-single(Wrapped)->single<V, E>;
+  requires Invocable<DF&>
+single(DF) -> single<ignoreVF, abortEF, DF>;
 
 template <class VF, class EF>
-    requires !Receiver<VF> && !detail::is_v<VF, on_error> &&
-    !detail::is_v<VF, on_done> && !detail::is_v<EF, on_value> &&
-    !detail::is_v<EF, on_done> && !Invocable<VF&> && !Invocable<EF&>
 single(VF, EF) -> single<VF, EF, ignoreDF>;
 
-template <class... EFN, class DF>
-single(on_error<EFN...>, on_done<DF>) ->
-    single<ignoreVF, on_error<EFN...>, on_done<DF>>;
+template <class EF, class DF>
+  requires Invocable<DF&>
+single(EF, DF) -> single<ignoreVF, EF, DF>;
 
 template <class VF, class EF, class DF>
-  requires !Invocable<VF&> && !Invocable<EF&> && Invocable<DF&>
-single(VF, EF, DF)->single<VF, EF, DF>;
+  requires Invocable<DF&>
+single(VF, EF, DF) -> single<VF, EF, DF>;
 
 template <Receiver<single_tag> Data>
 single(Data d) -> single<Data, passDVF, passDEF, passDDF>;
 
 template <Receiver<single_tag> Data, class DVF>
-    requires !detail::is_v<DVF, on_error> &&
-    !detail::is_v<DVF, on_done>
-single(Data d, DVF vf)
-    ->single<Data, DVF, passDEF, passDDF>;
+single(Data d, DVF vf) -> single<Data, DVF, passDEF, passDDF>;
 
 template <Receiver<single_tag> Data, class... DEFN>
-single(Data d, on_error<DEFN...>)
-    ->single<Data, passDVF, on_error<DEFN...>, passDDF>;
-
-template <Receiver<single_tag> Data, class DVF, class DEF>
-    requires !detail::is_v<DVF, on_error> && !detail::is_v<DVF, on_done> &&
-    !detail::is_v<DEF, on_done> && !Invocable<DVF&, Data&> && !Invocable<DEF&, Data&>
-single(Data d, DVF vf, DEF ef) -> single<Data, DVF, DEF, passDDF>;
-
-template <Receiver<single_tag> Data, class... DEFN, class DDF>
-single(Data d, on_error<DEFN...>, on_done<DDF>) ->
-    single<Data, passDVF, on_error<DEFN...>, on_done<DDF>>;
+single(Data d, on_error<DEFN...>) ->
+    single<Data, passDVF, on_error<DEFN...>, passDDF>;
 
 template <Receiver<single_tag> Data, class DDF>
-single(Data d, on_done<DDF>)->single<Data, passDVF, passDEF, on_done<DDF>>;
+  requires Invocable<DDF&, Data&>
+single(Data d, DDF) -> single<Data, passDVF, passDEF, DDF>;
+
+template <Receiver<single_tag> Data, class DVF, class DEF>
+single(Data d, DVF vf, DEF ef) -> single<Data, DVF, DEF, passDDF>;
+
+template <Receiver<single_tag> Data, class DEF, class DDF>
+  requires Invocable<DDF&, Data&>
+single(Data d, DEF, DDF) -> single<Data, passDVF, DEF, DDF>;
 
 template <Receiver<single_tag> Data, class DVF, class DEF, class DDF>
-requires !Invocable<DVF&, Data&> && !Invocable<DEF&, Data&> && Invocable<DDF&, Data&>
 single(Data d, DVF vf, DEF ef, DDF df) -> single<Data, DVF, DEF, DDF>;
 
 template <class V, class E = std::exception_ptr>
@@ -339,12 +331,12 @@ using any_single = single<V, E>;
 //   return single<V, E>{std::move(w)};
 // }
 
-template<class T>
-std::future<T> future_from(auto singleSender) {
+template<class T, SenderTo<std::promise<T>, single_tag> Out>
+std::future<T> future_from(Out singleSender) {
   std::promise<T> p;
   auto result = p.get_future();
-  submit(singleSender, single{std::move(p)});
+  submit(singleSender, std::move(p));
   return result;
 }
 
-} // namespace values
+} // namespace pushmi

--- a/include/pushmi/traits.h
+++ b/include/pushmi/traits.h
@@ -4,6 +4,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <functional>
 #include <type_traits>
 
 namespace pushmi {
@@ -101,12 +102,11 @@ using requires_ = std::enable_if_t<B, T>;
 } // namespace pushmi
 
 #if 1
+#define PUSHMI_VOID_LAMBDA_REQUIRES(...) \
+  ->::pushmi::detail::requires_<(__VA_ARGS__)>
 
-#define PUSHMI_VOID_LAMBDA_REQUIRES(RequiresExp...) \
-  ->::pushmi::detail::requires_<(RequiresExp)>
-
-#define PUSHMI_T_LAMBDA_REQUIRES(T, RequiresExp...) \
-  ->::pushmi::detail::requires_<(RequiresExp), T>
+#define PUSHMI_T_LAMBDA_REQUIRES(T, ...) \
+  ->::pushmi::detail::requires_<(__VA_ARGS__), T>
 #elif 0
 
 // unsupported syntax..

--- a/test/PushmiTest.cpp
+++ b/test/PushmiTest.cpp
@@ -32,10 +32,10 @@ SCENARIO( "empty can be used with tap and submit", "[empty][deferred]" ) {
       int signals = 0;
       e |
         op::tap(
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; }) |
         op::submit(
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; });
 
       THEN( "the done signal is recorded twice" ) {
@@ -63,11 +63,11 @@ SCENARIO( "empty can be used with tap and submit", "[empty][deferred]" ) {
       e |
         op::tap(
           [&](auto v){ signals += 100; },
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; }) |
         op::submit(
           [&](auto v){ signals += 100; },
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; });
 
       THEN( "the done signal is recorded twice" ) {
@@ -96,7 +96,7 @@ SCENARIO( "just() can be used with transform and submit", "[just][deferred]" ) {
           [&](int v){ signals += 10000; return v * 2; }) |
         op::submit(
           [&](auto v){ value = v; signals += 100; },
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; });
 
       THEN( "the transform signal is recorded twice, the value signal once and the result is correct" ) {

--- a/test/TrampolineTest.cpp
+++ b/test/TrampolineTest.cpp
@@ -56,7 +56,7 @@ SCENARIO( "trampoline executor", "[trampoline][deferred]" ) {
         op::submit(
           [&](auto at){ signaled = at;
             signals += 100; },
-          [&](auto e) noexcept {  signals += 1000; },
+          [&](auto e) noexcept { signals += 1000; },
           [&](){ signals += 10; });
 
       THEN( "the value signal is recorded once and the signal did not drift much" ) {


### PR DESCRIPTION
* Removes the pseudo-archetypes
* Simplify the class template argument deduction for `none` and `single`
* Replace `out_from` with a simpler implementation that constructs either a `none` or a `single` depending on the category of the incoming `Sender`.