### PR TITLE
Cpp14 support properties

### DIFF
--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -328,7 +328,7 @@ using constraint_t = decltype(::pushmi::top(std::declval<D&>()));
 // constraining generic lambdas.
 namespace mock {
 
-template <class Out, class Tag = silent_tag>
+template <class Out, class Tag = is_silent<>>
 struct Receiver {
   void operator()() requires pushmi::Receiver<Out, Tag> {}
 };
@@ -341,20 +341,20 @@ struct SingleReceiver {
   void operator()() requires pushmi::SingleReceiver<Out, V, E> {}
 };
 
-template <class D, class Tag = silent_tag>
+template <class D, class Tag = is_silent<>>
 struct Sender {
   void operator()() requires pushmi::Sender<D, Tag> {}
 };
-template <class D, class S, class Tag = silent_tag>
+template <class D, class S, class Tag = is_silent<>>
 struct SenderTo {
   void operator()() requires pushmi::SenderTo<D, S, Tag> {}
 };
 
-template <class D, class Tag = silent_tag>
+template <class D, class Tag = is_silent<>>
 struct TimeSender {
   void operator()() requires pushmi::TimeSender<D, Tag> {}
 };
-template <class D, class S, class Tag = silent_tag>
+template <class D, class S, class Tag = is_silent<>>
 struct TimeSenderTo {
   void operator()() requires pushmi::TimeSenderTo<D, S, Tag> {}
 };

--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -7,229 +7,161 @@
 
 #include "forwards.h"
 #include "extension_points.h"
+#include "properties.h"
 
 namespace pushmi {
 
-template <class T>
-using __category_t = typename T::category;
-
-template <class T>
-struct property_traits : property_traits<std::decay_t<T>> {
-};
-template <Decayed T>
-struct property_traits<T> {
-};
-template <Decayed T>
-  requires Valid<T, __category_t>
-struct property_traits<T> {
-  using category = __category_t<T>;
-};
-
-template <class T>
-using category_t = __category_t<property_traits<T>>;
-
-template<class T>
-concept bool Property = Valid<T, category_t>;
-
-
-template<class PropertySet0, class... PropertySetN>
-struct property_set_insert;
-
-template<class... Properties0, class Property0, class... PropertyN>
-  requires Property<Property0>
-struct property_set_insert<property_set<Properties0...>, Property0, PropertyN...> {
-  using type = typename property_set_insert<property_set<Properties0..., Properties0...>, PropertyN...>::type;
-};
-
-template<class... Properties0, class... Properties1, class... PropertySetN>
-struct property_set_insert<property_set<Properties0...>, property_set<Properties1...>, PropertySetN...> {
-  using type = typename property_set_insert<property_set<Properties0..., Properties1...>, PropertySetN...>::type;
-};
-
-template<class... Properties0, class Property, class... PropertySetN>
-struct property_set_insert<property_set<Properties0...>, Property, PropertySetN...> {
-  using type = typename property_set_insert<property_set<Properties0..., Property>, PropertySetN...>::type;
-};
-
-template<class... Properties0>
-struct property_set_insert<property_set<Properties0...>> {
-  using type = property_set<Properties0...>;
-};
-
-template<class PropertySet0, class Category>
-struct property_from_category;
-
-template<class Property0, class... PropertyN, Property P>
-struct property_from_category<property_set<Property0, PropertyN...>, P> {
-  using type = typename property_from_category<property_set<Property0, PropertyN...>, category_t<P>>::type;
-};
-
-template<class Category, Property Property0, Property... PropertyN>
-  requires !Property<Category>
-struct property_from_category<property_set<Property0, PropertyN...>, Category> {
-  using type = typename property_from_category<property_set<PropertyN...>, Category>::type;
-};
-
-template<Property Property0, Property... PropertyN>
-struct property_from_category<property_set<Property0, PropertyN...>, category_t<Property0>> {
-  using type = Property0;
-};
-
-template<class Category>
-struct property_from_category<property_set<>, Category> {
-};
-
-template<class T, class... Set>
-concept bool FoundIn = 
-  requires(T&, Set&...) {
-    (std::is_same<T, Set>::value || ... || false) == true;
-  };
-
-template<class... PropertyN>
-concept bool UniqueCategory = 
-  (Property<PropertyN> && ... && true) &&
-  requires(PropertyN&...) {
-    (FoundIn<category_t<PropertyN>, category_t<PropertyN>...> && ... && true) == true;
-  };
-
-template<class... PropertyN>
-struct property_set : PropertyN... {
-  static_assert((Property<PropertyN> && ... && true), "property_set only supports types that match the Property concept");
-  static_assert(UniqueCategory<PropertyN...>, "property_set has multiple properties from the same category");
-
-  // hide category in inherited types
-  struct property_set_is_not_a_property;
-  using category = property_set_is_not_a_property;
-
-  template<class PropertySet>
-  using insert_t = typename property_set_insert<property_set, PropertySet>::type;
-  template<class Category>
-  using from_category_t = typename property_from_category<property_set, Category>::type;
-};
-
-template<class T>
-concept bool PropertySet = detail::is_v<T, property_set>;
-
-template <class T>
-using __properties_t = typename T::properties;
-
-template <class T>
-struct property_set_traits : property_traits<std::decay_t<T>> {
-};
-template <Decayed T>
-struct property_set_traits<T> {
-};
-template <Decayed T>
-  requires Valid<T, __properties_t>
-struct property_set_traits<T> {
-  using properties = __properties_t<T>;
-};
-
-template <class T>
-  requires PropertySet<__properties_t<property_set_traits<T>>>
-using properties_t = __properties_t<property_set_traits<T>>;
-
-template<class T>
-concept bool Properties = Valid<T, properties_t>;
-
-template<Property... PropertyN, Property Expected>
-constexpr bool PropertyQueryBase(const property_set<PropertyN...>&, const Expected&) { 
-  return (Derived<PropertyN, Expected> || ... || false);
-}
-template<Property... PropertyN, Property... ExpectedN>
-constexpr bool PropertySetQueryBase(const property_set<PropertyN...>& ps, const property_set<ExpectedN...>&) { 
-  return (PropertyQueryBase(ps, ExpectedN{}) && ... && true);
-}
-template<Property... PropertyN, Property Expected>
-constexpr bool PropertyCategoryQueryBase(const property_set<PropertyN...>&, const Expected&) { 
-  return (Same<category_t<PropertyN>, category_t<Expected>> || ... || false);
-}
-template<Property... PropertyN, Property... ExpectedN>
-constexpr bool PropertySetCategoryQueryBase(const property_set<PropertyN...>& ps, const property_set<ExpectedN...>&) { 
-  return (PropertyCategoryQueryBase(ps, ExpectedN{}) && ... && true);
-}
-
-template<class PS, class... ExpectedN>
-concept bool PropertyQuery = Properties<PS> && 
-  (Property<ExpectedN> && ... && true) &&
-  (PropertyQueryBase(properties_t<PS>{}, ExpectedN{}) && ... && true);
-
-template<class PS, class Expected>
-concept bool PropertySetQuery = Properties<PS> &&
-  PropertySet<Expected> &&
-  PropertySetQueryBase(properties_t<PS>{}, Expected{});
-
-template<class PS, class... ExpectedN>
-concept bool PropertyCategoryQuery = Properties<PS> &&
-  (Property<ExpectedN> && ... && true) &&
-  (PropertyCategoryQueryBase(properties_t<PS>{}, ExpectedN{}) && ... && true);
-
-template<class PS, class Expected>
-concept bool PropertySetCategoryQuery = Properties<PS> &&
-  PropertySet<Expected> &&
-  PropertySetCategoryQueryBase(properties_t<PS>{}, Expected{});
-
-
-// tag types
-struct cardinality_category {};
-struct silent_tag { using category = cardinality_category;};
-struct none_tag : silent_tag {};
-struct single_tag : none_tag {};
-struct many_tag : single_tag {};
-
-struct flow_category {};
-struct flow_tag {using category = flow_category;};
-
-struct receiver_category {};
-struct receiver_tag {using category = receiver_category;};
-
-struct sender_category {};
-struct sender_tag {using category = sender_category;};
-
-struct time_tag : sender_tag {  };
-struct constrained_tag : sender_tag {  };
+// traits & tags
 
 // cardinality affects both sender and receiver
 
-template <class PS>
-concept bool Silent = PropertyQuery<PS, silent_tag>;
-
-template <class PS>
-concept bool None = Silent<PS> && PropertyQuery<PS, none_tag>;
-
-template <class PS>
-concept bool Single = None<PS> && PropertyQuery<PS, single_tag>;
-
-template <class PS>
-concept bool Many = Single<PS> && PropertyQuery<PS, many_tag>;
+struct cardinality_category {};
 
 // flow affects both sender and receiver
 
-template <class PS>
-concept bool Flow = PropertyQuery<PS, flow_tag>;
-
-// time and constrained are mutually exclusive (time is a special case of constrained and may be folded in later)
-
-template <class PS>
-concept bool Time = PropertyQuery<PS, time_tag>;
-
-template <class PS>
-concept bool Constrained = PropertyQuery<PS, constrained_tag>;
+struct flow_category {};
 
 // sender and receiver are mutually exclusive
 
+struct receiver_category {};
+
+struct sender_category {};
+
+// time and constrained are mutually exclusive refinements of sender (time is a special case of constrained and may be folded in later)
+
+
+// Silent trait and tag
+template<class... TN>
+struct is_silent;
+// Tag
+template<>
+struct is_silent<> { using property_category = cardinality_category; };
+// Trait
+template<class PS>
+struct is_silent<PS> : property_query<PS, is_silent<>> {};
+template<class PS>
+inline constexpr bool is_silent_v = is_silent<PS>::value;
 template <class PS>
-concept bool Receiver = PropertyQuery<PS, receiver_tag> && Silent<PS>;
+concept bool Silent = is_silent_v<PS>;
 
+// None trait and tag
+template<class... TN>
+struct is_none;
+// Tag
+template<>
+struct is_none<> : is_silent<> {};
+// Trait
+template<class PS>
+struct is_none<PS> : property_query<PS, is_none<>> {};
+template<class PS>
+inline constexpr bool is_none_v = is_none<PS>::value;
 template <class PS>
-concept bool Sender = PropertyQuery<PS, sender_tag> && Silent<PS>;
+concept bool None = is_none_v<PS>;
+
+// Single trait and tag
+template<class... TN>
+struct is_single;
+// Tag
+template<>
+struct is_single<> : is_none<> {};
+// Trait
+template<class PS>
+struct is_single<PS> : property_query<PS, is_single<>> {};
+template<class PS>
+inline constexpr bool is_single_v = is_single<PS>::value;
+template <class PS>
+concept bool Single = is_single_v<PS>;
+
+// Many trait and tag
+template<class... TN>
+struct is_many;
+// Tag
+template<>
+struct is_many<> : is_none<> {}; // many::value() does not terminate, so it is not a refinement of single
+// Trait
+template<class PS>
+struct is_many<PS> : property_query<PS, is_many<>> {};
+template<class PS>
+inline constexpr bool is_many_v = is_many<PS>::value;
+template <class PS>
+concept bool Many = is_many_v<PS>;
 
 
+// Flow trait and tag
+template<class... TN>
+struct is_flow;
+// Tag
+template<>
+struct is_flow<> { using property_category = flow_category; };
+// Trait
+template<class PS>
+struct is_flow<PS> : property_query<PS, is_flow<>> {};
+template<class PS>
+inline constexpr bool is_flow_v = is_flow<PS>::value;
+template <class PS>
+concept bool Flow = is_flow_v<PS>;
+
+
+// Receiver trait and tag
+template<class... TN>
+struct is_receiver;
+// Tag
+template<>
+struct is_receiver<> { using property_category = receiver_category; };
+// Trait
+template<class PS>
+struct is_receiver<PS> : property_query<PS, is_receiver<>> {};
+template<class PS>
+inline constexpr bool is_receiver_v = is_receiver<PS>::value;
+template <class PS>
+concept bool Receiver = is_receiver_v<PS>;
+
+
+// Sender trait and tag
+template<class... TN>
+struct is_sender;
+// Tag
+template<>
+struct is_sender<> { using property_category = sender_category; };
+// Trait
+template<class PS>
+struct is_sender<PS> : property_query<PS, is_sender<>> {};
+template<class PS>
+inline constexpr bool is_sender_v = is_sender<PS>::value;
+template <class PS>
+concept bool Sender = is_sender_v<PS>;
+
+// Time trait and tag
+template<class... TN>
+struct is_time;
+// Tag
+template<>
+struct is_time<> : is_sender<> {};
+// Trait
+template<class PS>
+struct is_time<PS> : property_query<PS, is_time<>> {};
+template<class PS>
+inline constexpr bool is_time_v = is_time<PS>::value;
+template <class PS>
+concept bool Time = is_time_v<PS>;
+
+// Constrained trait and tag
+template<class... TN>
+struct is_constrained;
+// Tag
+template<>
+struct is_constrained<> : is_sender<> {};
+// Trait
+template<class PS>
+struct is_constrained<PS> : property_query<PS, is_constrained<>> {};
+template<class PS>
+inline constexpr bool is_constrained_v = is_constrained<PS>::value;
+template <class PS>
+concept bool Constrained = is_constrained_v<PS>;
 
 
 template <class S>
 concept bool SilentReceiver = SemiMovable<S> && 
-  Silent<S> && 
   Receiver<S> &&
   requires (S& s) {
     ::pushmi::set_done(s);
@@ -253,7 +185,7 @@ concept bool SingleReceiver = NoneReceiver<S, E> &&
   };
 
 template <class S, class T, class E = std::exception_ptr>
-concept bool ManyReceiver = SingleReceiver<S, T, E> &&
+concept bool ManyReceiver = NoneReceiver<S, E> &&
   SemiMovable<T> &&
   SemiMovable<E> &&
   Many<S>;
@@ -262,7 +194,7 @@ concept bool ManyReceiver = SingleReceiver<S, T, E> &&
 
 
 // silent does not really make sense, but cannot test for
-// None without the error type, use none_tag to strengthen 
+// None without the error type, use is_none<> to strengthen 
 // requirements
 template <class D>
 concept bool SilentSender = SemiMovable<D> &&
@@ -281,16 +213,11 @@ concept bool SenderTo = SilentSender<D> &&
 //
 
 template <class S>
-concept bool FlowSilentSender = SilentSender<S> &&
-  Flow<S>;
-
-template <class S, class... PropertyN>
 concept bool FlowSilentReceiver = SilentReceiver<S> &&
-  Flow<S>;
-
-template <class D, class S>
-concept bool FlowSenderTo = FlowSilentSender<D> &&
-  FlowSilentReceiver<S>;
+  Flow<S> &&
+  requires(S& s) {
+    ::pushmi::set_stopping(s);
+  };
 
 template <
   class N, 
@@ -303,9 +230,8 @@ concept bool FlowNoneReceiver = FlowSilentReceiver<N> &&
   SemiMovable<E> &&
   NoneReceiver<Up, PE> && 
   NoneReceiver<N, E> &&
-  requires(N& n, Up&& up) {
-    ::pushmi::set_stopping(n);
-    ::pushmi::set_starting(n, (Up&&) up);
+  requires(N& n, Up& up) {
+    ::pushmi::set_starting(n, up);
   };
 
 template <
@@ -328,6 +254,13 @@ concept bool FlowManyReceiver =
   ManyReceiver<S, T, E> && 
   FlowSingleReceiver<S, Up, T, PE, E>;
 
+template <class S>
+concept bool FlowSilentSender = SilentSender<S> &&
+  Flow<S>;
+
+template <class D, class S>
+concept bool FlowSenderTo = FlowSilentSender<D> &&
+  FlowSilentReceiver<S>;
 
 // add concepts for constraints
 //

--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -40,7 +40,7 @@ struct is_silent<> { using property_category = cardinality_category; };
 template<class PS>
 struct is_silent<PS> : property_query<PS, is_silent<>> {};
 template<class PS>
-inline constexpr bool is_silent_v = is_silent<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_silent_v = is_silent<PS>::value;
 template <class PS>
 concept bool Silent = is_silent_v<PS>;
 
@@ -54,7 +54,7 @@ struct is_none<> : is_silent<> {};
 template<class PS>
 struct is_none<PS> : property_query<PS, is_none<>> {};
 template<class PS>
-inline constexpr bool is_none_v = is_none<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_none_v = is_none<PS>::value;
 template <class PS>
 concept bool None = is_none_v<PS>;
 
@@ -68,7 +68,7 @@ struct is_single<> : is_none<> {};
 template<class PS>
 struct is_single<PS> : property_query<PS, is_single<>> {};
 template<class PS>
-inline constexpr bool is_single_v = is_single<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_single_v = is_single<PS>::value;
 template <class PS>
 concept bool Single = is_single_v<PS>;
 
@@ -82,7 +82,7 @@ struct is_many<> : is_none<> {}; // many::value() does not terminate, so it is n
 template<class PS>
 struct is_many<PS> : property_query<PS, is_many<>> {};
 template<class PS>
-inline constexpr bool is_many_v = is_many<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_many_v = is_many<PS>::value;
 template <class PS>
 concept bool Many = is_many_v<PS>;
 
@@ -97,7 +97,7 @@ struct is_flow<> { using property_category = flow_category; };
 template<class PS>
 struct is_flow<PS> : property_query<PS, is_flow<>> {};
 template<class PS>
-inline constexpr bool is_flow_v = is_flow<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_flow_v = is_flow<PS>::value;
 template <class PS>
 concept bool Flow = is_flow_v<PS>;
 
@@ -112,9 +112,9 @@ struct is_receiver<> { using property_category = receiver_category; };
 template<class PS>
 struct is_receiver<PS> : property_query<PS, is_receiver<>> {};
 template<class PS>
-inline constexpr bool is_receiver_v = is_receiver<PS>::value;
-template <class PS>
-concept bool Receiver = is_receiver_v<PS>;
+PUSHMI_INLINE_VAR constexpr bool is_receiver_v = is_receiver<PS>::value;
+// template <class PS>
+// concept bool Receiver = is_receiver_v<PS>;
 
 
 // Sender trait and tag
@@ -127,9 +127,9 @@ struct is_sender<> { using property_category = sender_category; };
 template<class PS>
 struct is_sender<PS> : property_query<PS, is_sender<>> {};
 template<class PS>
-inline constexpr bool is_sender_v = is_sender<PS>::value;
-template <class PS>
-concept bool Sender = is_sender_v<PS>;
+PUSHMI_INLINE_VAR constexpr bool is_sender_v = is_sender<PS>::value;
+// template <class PS>
+// concept bool Sender = is_sender_v<PS>;
 
 // Time trait and tag
 template<class... TN>
@@ -141,7 +141,7 @@ struct is_time<> : is_sender<> {};
 template<class PS>
 struct is_time<PS> : property_query<PS, is_time<>> {};
 template<class PS>
-inline constexpr bool is_time_v = is_time<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_time_v = is_time<PS>::value;
 template <class PS>
 concept bool Time = is_time_v<PS>;
 
@@ -155,20 +155,21 @@ struct is_constrained<> : is_sender<> {};
 template<class PS>
 struct is_constrained<PS> : property_query<PS, is_constrained<>> {};
 template<class PS>
-inline constexpr bool is_constrained_v = is_constrained<PS>::value;
+PUSHMI_INLINE_VAR constexpr bool is_constrained_v = is_constrained<PS>::value;
 template <class PS>
 concept bool Constrained = is_constrained_v<PS>;
 
 
-template <class S>
-concept bool SilentReceiver = SemiMovable<S> && 
-  Receiver<S> &&
+template <class S, class... PropertyN>
+concept bool Receiver = SemiMovable<S> && 
+  property_query_v<S, PropertyN...> &&
+  is_receiver_v<S> &&
   requires (S& s) {
     ::pushmi::set_done(s);
   };
 
 template <class N, class E = std::exception_ptr>
-concept bool NoneReceiver = SilentReceiver<N> &&
+concept bool NoneReceiver = Receiver<N> &&
   None<N> &&
   SemiMovable<E> &&
   requires(N& n, E&& e) {
@@ -196,14 +197,16 @@ concept bool ManyReceiver = NoneReceiver<S, E> &&
 // silent does not really make sense, but cannot test for
 // None without the error type, use is_none<> to strengthen 
 // requirements
-template <class D>
-concept bool SilentSender = SemiMovable<D> &&
+template <class D, class... PropertyN>
+concept bool Sender = SemiMovable<D> &&
   None<D> && 
-  Sender<D>;
+  property_query_v<D, PropertyN...> &&
+  is_sender_v<D>;
 
-template <class D, class S>
-concept bool SenderTo = SilentSender<D> &&
-  SilentReceiver<S> &&
+template <class D, class S, class... PropertyN>
+concept bool SenderTo = Sender<D> &&
+  Receiver<S> &&
+  property_query_v<D, PropertyN...> &&
   requires(D& d, S&& s) {
     ::pushmi::submit(d, (S &&) s);
   };
@@ -212,8 +215,9 @@ concept bool SenderTo = SilentSender<D> &&
 // add concepts to support cancellation
 //
 
-template <class S>
-concept bool FlowSilentReceiver = SilentReceiver<S> &&
+template <class S, class... PropertyN>
+concept bool FlowReceiver = Receiver<S> &&
+  property_query_v<S, PropertyN...> &&
   Flow<S> &&
   requires(S& s) {
     ::pushmi::set_stopping(s);
@@ -224,8 +228,8 @@ template <
   class Up, 
   class PE = std::exception_ptr,
   class E = PE>
-concept bool FlowNoneReceiver = FlowSilentReceiver<N> && 
-  SilentReceiver<Up> &&
+concept bool FlowNoneReceiver = FlowReceiver<N> && 
+  Receiver<Up> &&
   SemiMovable<PE> &&
   SemiMovable<E> &&
   NoneReceiver<Up, PE> && 
@@ -254,34 +258,38 @@ concept bool FlowManyReceiver =
   ManyReceiver<S, T, E> && 
   FlowSingleReceiver<S, Up, T, PE, E>;
 
-template <class S>
-concept bool FlowSilentSender = SilentSender<S> &&
+template <class S, class... PropertyN>
+concept bool FlowSender = Sender<S> &&
+  property_query_v<S, PropertyN...> &&
   Flow<S>;
 
-template <class D, class S>
-concept bool FlowSenderTo = FlowSilentSender<D> &&
-  FlowSilentReceiver<S>;
+template <class D, class S, class... PropertyN>
+concept bool FlowSenderTo = FlowSender<D> &&
+  property_query_v<D, PropertyN...> &&
+  FlowReceiver<S>;
 
 // add concepts for constraints
 //
 
-template <class D>
-concept bool TimeSilentSender = SilentSender<D> && 
+template <class D, class... PropertyN>
+concept bool TimeSender = Sender<D> && 
+  property_query_v<D, PropertyN...> &&
   Time<D> && 
   None<D> &&
   requires(D& d) {
     { ::pushmi::now(d) } -> Regular
   };
 
-template <class D, class S>
-concept bool TimeSenderTo = TimeSilentSender<D> && 
-  SilentReceiver<S> &&
+template <class D, class S, class... PropertyN>
+concept bool TimeSenderTo = TimeSender<D> && 
+  property_query_v<D, PropertyN...> &&
+  Receiver<S> &&
   requires(D& d, S&& s) {
     ::pushmi::submit(d, ::pushmi::now(d), (S &&) s);
   };
 
 template <class D>
-  requires TimeSilentSender<D>
+  requires TimeSender<D>
 using time_point_t = decltype(::pushmi::now(std::declval<D&>()));
 
 
@@ -295,7 +303,7 @@ using time_point_t = decltype(::pushmi::now(std::declval<D&>()));
 // obscure too much.
 
 template <class D>
-concept bool ConstrainedSilentSender = SilentSender<D> &&
+concept bool ConstrainedSender = Sender<D> &&
   Constrained<D> &&
   None<D> && 
   requires(D& d) {
@@ -303,14 +311,14 @@ concept bool ConstrainedSilentSender = SilentSender<D> &&
   };
 
 template <class D, class S>
-concept bool ConstrainedSenderTo = ConstrainedSilentSender<D> && 
-  SilentReceiver<S> &&
+concept bool ConstrainedSenderTo = ConstrainedSender<D> && 
+  Receiver<S> &&
   requires(D& d, S&& s) {
     ::pushmi::submit(d, ::pushmi::top(d), (S &&) s);
   };
 
 template <class D>
-  requires ConstrainedSilentSender<D>
+  requires ConstrainedSender<D>
 using constraint_t = decltype(::pushmi::top(std::declval<D&>()));
 
 

--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -10,179 +10,376 @@
 
 namespace pushmi {
 
+template <class T>
+using __category_t = typename T::category;
+
+template <class T>
+struct property_traits : property_traits<std::decay_t<T>> {
+};
+template <Decayed T>
+struct property_traits<T> {
+};
+template <Decayed T>
+  requires Valid<T, __category_t>
+struct property_traits<T> {
+  using category = __category_t<T>;
+};
+
+template <class T>
+using category_t = __category_t<property_traits<T>>;
+
+template<class T>
+concept bool Property = Valid<T, category_t>;
+
+
+template<class PropertySet0, class... PropertySetN>
+struct property_set_insert;
+
+template<class... Properties0, class Property0, class... PropertyN>
+  requires Property<Property0>
+struct property_set_insert<property_set<Properties0...>, Property0, PropertyN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Properties0...>, PropertyN...>::type;
+};
+
+template<class... Properties0, class... Properties1, class... PropertySetN>
+struct property_set_insert<property_set<Properties0...>, property_set<Properties1...>, PropertySetN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Properties1...>, PropertySetN...>::type;
+};
+
+template<class... Properties0, class Property, class... PropertySetN>
+struct property_set_insert<property_set<Properties0...>, Property, PropertySetN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Property>, PropertySetN...>::type;
+};
+
+template<class... Properties0>
+struct property_set_insert<property_set<Properties0...>> {
+  using type = property_set<Properties0...>;
+};
+
+template<class PropertySet0, class Category>
+struct property_from_category;
+
+template<class Property0, class... PropertyN, Property P>
+struct property_from_category<property_set<Property0, PropertyN...>, P> {
+  using type = typename property_from_category<property_set<Property0, PropertyN...>, category_t<P>>::type;
+};
+
+template<class Category, Property Property0, Property... PropertyN>
+  requires !Property<Category>
+struct property_from_category<property_set<Property0, PropertyN...>, Category> {
+  using type = typename property_from_category<property_set<PropertyN...>, Category>::type;
+};
+
+template<Property Property0, Property... PropertyN>
+struct property_from_category<property_set<Property0, PropertyN...>, category_t<Property0>> {
+  using type = Property0;
+};
+
+template<class Category>
+struct property_from_category<property_set<>, Category> {
+};
+
+template<class T, class... Set>
+concept bool FoundIn = 
+  requires(T&, Set&...) {
+    (std::is_same<T, Set>::value || ... || false) == true;
+  };
+
+template<class... PropertyN>
+concept bool UniqueCategory = 
+  (Property<PropertyN> && ... && true) &&
+  requires(PropertyN&...) {
+    (FoundIn<category_t<PropertyN>, category_t<PropertyN>...> && ... && true) == true;
+  };
+
+template<class... PropertyN>
+struct property_set : PropertyN... {
+  static_assert((Property<PropertyN> && ... && true), "property_set only supports types that match the Property concept");
+  static_assert(UniqueCategory<PropertyN...>, "property_set has multiple properties from the same category");
+
+  // hide category in inherited types
+  struct property_set_is_not_a_property;
+  using category = property_set_is_not_a_property;
+
+  template<class PropertySet>
+  using insert_t = typename property_set_insert<property_set, PropertySet>::type;
+  template<class Category>
+  using from_category_t = typename property_from_category<property_set, Category>::type;
+};
+
+template<class T>
+concept bool PropertySet = detail::is_v<T, property_set>;
+
+template <class T>
+using __properties_t = typename T::properties;
+
+template <class T>
+struct property_set_traits : property_traits<std::decay_t<T>> {
+};
+template <Decayed T>
+struct property_set_traits<T> {
+};
+template <Decayed T>
+  requires Valid<T, __properties_t>
+struct property_set_traits<T> {
+  using properties = __properties_t<T>;
+};
+
+template <class T>
+  requires PropertySet<__properties_t<property_set_traits<T>>>
+using properties_t = __properties_t<property_set_traits<T>>;
+
+template<class T>
+concept bool Properties = Valid<T, properties_t>;
+
+template<Property... PropertyN, Property Expected>
+constexpr bool PropertyQueryBase(const property_set<PropertyN...>&, const Expected&) { 
+  return (Derived<PropertyN, Expected> || ... || false);
+}
+template<Property... PropertyN, Property... ExpectedN>
+constexpr bool PropertySetQueryBase(const property_set<PropertyN...>& ps, const property_set<ExpectedN...>&) { 
+  return (PropertyQueryBase(ps, ExpectedN{}) && ... && true);
+}
+template<Property... PropertyN, Property Expected>
+constexpr bool PropertyCategoryQueryBase(const property_set<PropertyN...>&, const Expected&) { 
+  return (Same<category_t<PropertyN>, category_t<Expected>> || ... || false);
+}
+template<Property... PropertyN, Property... ExpectedN>
+constexpr bool PropertySetCategoryQueryBase(const property_set<PropertyN...>& ps, const property_set<ExpectedN...>&) { 
+  return (PropertyCategoryQueryBase(ps, ExpectedN{}) && ... && true);
+}
+
+template<class PS, class... ExpectedN>
+concept bool PropertyQuery = Properties<PS> && 
+  (Property<ExpectedN> && ... && true) &&
+  (PropertyQueryBase(properties_t<PS>{}, ExpectedN{}) && ... && true);
+
+template<class PS, class Expected>
+concept bool PropertySetQuery = Properties<PS> &&
+  PropertySet<Expected> &&
+  PropertySetQueryBase(properties_t<PS>{}, Expected{});
+
+template<class PS, class... ExpectedN>
+concept bool PropertyCategoryQuery = Properties<PS> &&
+  (Property<ExpectedN> && ... && true) &&
+  (PropertyCategoryQueryBase(properties_t<PS>{}, ExpectedN{}) && ... && true);
+
+template<class PS, class Expected>
+concept bool PropertySetCategoryQuery = Properties<PS> &&
+  PropertySet<Expected> &&
+  PropertySetCategoryQueryBase(properties_t<PS>{}, Expected{});
+
+
 // tag types
-struct silent_tag {};
+struct cardinality_category {};
+struct silent_tag { using category = cardinality_category;};
 struct none_tag : silent_tag {};
 struct single_tag : none_tag {};
-struct flow_tag : single_tag {};
+struct many_tag : single_tag {};
+
+struct flow_category {};
+struct flow_tag {using category = flow_category;};
+
+struct receiver_category {};
+struct receiver_tag {using category = receiver_category;};
+
+struct sender_category {};
+struct sender_tag {using category = sender_category;};
+
+struct time_tag : sender_tag {  };
+struct constrained_tag : sender_tag {  };
+
+// cardinality affects both sender and receiver
+
+template <class PS>
+concept bool Silent = PropertyQuery<PS, silent_tag>;
+
+template <class PS>
+concept bool None = Silent<PS> && PropertyQuery<PS, none_tag>;
+
+template <class PS>
+concept bool Single = None<PS> && PropertyQuery<PS, single_tag>;
+
+template <class PS>
+concept bool Many = Single<PS> && PropertyQuery<PS, many_tag>;
+
+// flow affects both sender and receiver
+
+template <class PS>
+concept bool Flow = PropertyQuery<PS, flow_tag>;
+
+// time and constrained are mutually exclusive (time is a special case of constrained and may be folded in later)
+
+template <class PS>
+concept bool Time = PropertyQuery<PS, time_tag>;
+
+template <class PS>
+concept bool Constrained = PropertyQuery<PS, constrained_tag>;
+
+// sender and receiver are mutually exclusive
+
+template <class PS>
+concept bool Receiver = PropertyQuery<PS, receiver_tag> && Silent<PS>;
+
+template <class PS>
+concept bool Sender = PropertyQuery<PS, sender_tag> && Silent<PS>;
 
 
-template <class T>
-using __sender_category_t = typename T::sender_category;
-
-template <class T>
-struct sender_traits : sender_traits<std::decay_t<T>> {
-};
-template <Decayed T>
-struct sender_traits<T> {
-};
-template <Decayed T>
-  requires Valid<T, __sender_category_t>
-struct sender_traits<T> {
-  using sender_category = __sender_category_t<T>;
-};
-
-template <class T>
-using sender_category_t = __sender_category_t<sender_traits<T>>;
-
-template <class T>
-using __receiver_category_t = typename T::receiver_category;
-
-template <class T>
-struct receiver_traits : receiver_traits<std::decay_t<T>> {
-};
-template <Decayed T>
-struct receiver_traits<T> {
-};
-template <Decayed T>
-  requires Valid<T, __receiver_category_t>
-struct receiver_traits<T> {
-  using receiver_category = __receiver_category_t<T>;
-};
-
-template <class T>
-using receiver_category_t = __receiver_category_t<receiver_traits<T>>;
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-// Receiver concepts
-template <class S, class Tag = silent_tag>
-concept bool Receiver = Valid<receiver_traits<S>, __receiver_category_t> &&
-  Derived<receiver_category_t<S>, Tag> &&
-  SemiMovable<S> && requires (S& s) {
+template <class S>
+concept bool SilentReceiver = SemiMovable<S> && 
+  Silent<S> && 
+  Receiver<S> &&
+  requires (S& s) {
     ::pushmi::set_done(s);
   };
 
-template <class S, class E = std::exception_ptr>
-concept bool NoneReceiver = Receiver<S> &&
-  Derived<receiver_category_t<S>, none_tag> &&
-  requires(S& s, E&& e) {
-    ::pushmi::set_error(s, (E &&) e);
+template <class N, class E = std::exception_ptr>
+concept bool NoneReceiver = SilentReceiver<N> &&
+  None<N> &&
+  SemiMovable<E> &&
+  requires(N& n, E&& e) {
+    ::pushmi::set_error(n, (E &&) e);
   };
 
 template <class S, class T, class E = std::exception_ptr>
 concept bool SingleReceiver = NoneReceiver<S, E> &&
-  Derived<receiver_category_t<S>, single_tag> &&
+  SemiMovable<T> &&
+  SemiMovable<E> &&
+  Single<S> &&
   requires(S& s, T&& t) {
     ::pushmi::set_value(s, (T &&) t); // Semantics: called exactly once.
   };
 
+template <class S, class T, class E = std::exception_ptr>
+concept bool ManyReceiver = SingleReceiver<S, T, E> &&
+  SemiMovable<T> &&
+  SemiMovable<E> &&
+  Many<S>;
 
-////////////////////////////////////////////////////////////////////////////////
-// Sender concepts
-template <class D, class Tag = silent_tag>
-concept bool Sender = Valid<sender_traits<D>, __sender_category_t> &&
-  Derived<sender_category_t<D>, Tag> && SemiMovable<D>;
 
-template <class D, class S, class Tag = silent_tag>
-concept bool SenderTo = Sender<D, Tag> &&
-  Derived<sender_category_t<D>, Tag> &&
-  Receiver<S, Tag> && requires(D& d, S&& s) {
+
+
+// silent does not really make sense, but cannot test for
+// None without the error type, use none_tag to strengthen 
+// requirements
+template <class D>
+concept bool SilentSender = SemiMovable<D> &&
+  None<D> && 
+  Sender<D>;
+
+template <class D, class S>
+concept bool SenderTo = SilentSender<D> &&
+  SilentReceiver<S> &&
+  requires(D& d, S&& s) {
     ::pushmi::submit(d, (S &&) s);
   };
 
 
-////////////////////////////////////////////////////////////////////////////////
-// TimeSender concepts
-template <class D, class Tag = silent_tag>
-concept bool TimeSender = Sender<D, Tag> && requires(D& d) {
-  { ::pushmi::now(d) } -> Regular
-};
-
-template <TimeSender D>
-using time_point_t = decltype(::pushmi::now(std::declval<D&>()));
-
-template <class D, class S, class Tag = silent_tag>
-concept bool TimeSenderTo = Receiver<S, Tag> && TimeSender<D, Tag> &&
-  requires(D& d, S&& s, time_point_t<D> tp) {
-    ::pushmi::submit(d, tp, (S &&) s);
-  };
-
-
-// // this is a more general form where C (Constraint) could be time or priority
-// // enum or any other ordering constraint value-type.
-// //
-// // top() returns the constraint value that will push the item as high in the
-// // queue as currently possible. So now() for time and HIGH for priority.
-// //
-// // I would like to replace Time.. with Priority.. but not sure if it will
-// // obscure too much.
-// template <class D>
-// concept bool PrioritySource = requires(D& d) {
-//   { ::pushmi::top(d) } -> Regular
-// };
-//
-// template <PrioritySource D>
-// using constraint_t = decltype(::pushmi::top(std::declval<D&>()));
-//
-// template <class D, class S>
-// concept bool SemiPrioritySender = requires(D& d, S&& s) {
-//   ::pushmi::submit(d, ::pushmi::top(d), (S &&) s);
-// };
-//
-// template <class D, class S, class E = std::exception_ptr>
-// concept bool PrioritySender =
-//     NoneReceiver<S, E> && SemiPrioritySender<D, S> &&
-//     PrioritySource<D> && requires(D& d, S& s) {
-//   { ::pushmi::top(d) } -> constraint_t<D>;
-// };
-//
-// template <class D, class S, class T, class E = std::exception_ptr>
-// concept bool PrioritySingleSender = SingleReceiver<S, T, E> &&
-//   PrioritySender<D, S, E>;
-//
-// template <class D, class S>
-// concept bool SemiPrioritySingleSender = SemiPrioritySender<D, S>;
-
 // add concepts to support cancellation
 //
 
-template <class N, class Up, class PE = std::exception_ptr>
-concept bool FlowNone = NoneReceiver<Up, PE> && requires(N& n, Up& up) {
-  ::pushmi::set_stopping(n);
-  ::pushmi::set_starting(n, up);
-};
+template <class S>
+concept bool FlowSilentSender = SilentSender<S> &&
+  Flow<S>;
 
-template <
-    class D,
-    class N,
-    class Up,
-    class PE = std::exception_ptr,
-    class E = PE>
-concept bool FlowNoneSender = FlowNone<N, Up, PE> &&
-  SenderTo<D, N> && NoneReceiver<N, E>;
-
-template <
-    class S,
-    class Up,
-    class T,
-    class PE = std::exception_ptr,
-    class E = PE>
-concept bool FlowSingle = SingleReceiver<S, T, E> && FlowNone<S, Up, PE>;
-
-template <
-    class D,
-    class S,
-    class Up,
-    class T,
-    class PE = std::exception_ptr,
-    class E = PE>
-concept bool FlowSingleSender =
-    FlowSingle<S, Up, T, PE, E> && FlowNoneSender<D, S, Up, PE, E>;
+template <class S, class... PropertyN>
+concept bool FlowSilentReceiver = SilentReceiver<S> &&
+  Flow<S>;
 
 template <class D, class S>
-concept bool SemiFlowSingleSender = SenderTo<D, S, single_tag>;
+concept bool FlowSenderTo = FlowSilentSender<D> &&
+  FlowSilentReceiver<S>;
+
+template <
+  class N, 
+  class Up, 
+  class PE = std::exception_ptr,
+  class E = PE>
+concept bool FlowNoneReceiver = FlowSilentReceiver<N> && 
+  SilentReceiver<Up> &&
+  SemiMovable<PE> &&
+  SemiMovable<E> &&
+  NoneReceiver<Up, PE> && 
+  NoneReceiver<N, E> &&
+  requires(N& n, Up&& up) {
+    ::pushmi::set_stopping(n);
+    ::pushmi::set_starting(n, (Up&&) up);
+  };
+
+template <
+    class S,
+    class Up,
+    class T,
+    class PE = std::exception_ptr,
+    class E = PE>
+concept bool FlowSingleReceiver = 
+  SingleReceiver<S, T, E> && 
+  FlowNoneReceiver<S, Up, PE, E>;
+
+template <
+    class S,
+    class Up,
+    class T,
+    class PE = std::exception_ptr,
+    class E = PE>
+concept bool FlowManyReceiver = 
+  ManyReceiver<S, T, E> && 
+  FlowSingleReceiver<S, Up, T, PE, E>;
+
+
+// add concepts for constraints
+//
+
+template <class D>
+concept bool TimeSilentSender = SilentSender<D> && 
+  Time<D> && 
+  None<D> &&
+  requires(D& d) {
+    { ::pushmi::now(d) } -> Regular
+  };
+
+template <class D, class S>
+concept bool TimeSenderTo = TimeSilentSender<D> && 
+  SilentReceiver<S> &&
+  requires(D& d, S&& s) {
+    ::pushmi::submit(d, ::pushmi::now(d), (S &&) s);
+  };
+
+template <class D>
+  requires TimeSilentSender<D>
+using time_point_t = decltype(::pushmi::now(std::declval<D&>()));
+
+
+// this is a more general form where the constraint could be time or priority
+// enum or any other ordering constraint value-type.
+//
+// top() returns the constraint value that will cause the item to run asap.
+// So now() for time and NORMAL for priority.
+//
+// I would like to replace Time.. with Constrained.. but not sure if it will
+// obscure too much.
+
+template <class D>
+concept bool ConstrainedSilentSender = SilentSender<D> &&
+  Constrained<D> &&
+  None<D> && 
+  requires(D& d) {
+    { ::pushmi::top(d) } -> Regular
+  };
+
+template <class D, class S>
+concept bool ConstrainedSenderTo = ConstrainedSilentSender<D> && 
+  SilentReceiver<S> &&
+  requires(D& d, S&& s) {
+    ::pushmi::submit(d, ::pushmi::top(d), (S &&) s);
+  };
+
+template <class D>
+  requires ConstrainedSilentSender<D>
+using constraint_t = decltype(::pushmi::top(std::declval<D&>()));
+
 
 
 

--- a/include/pushmi/executor.h
+++ b/include/pushmi/executor.h
@@ -27,12 +27,12 @@ private:
   using wrapped_t =
     std::enable_if_t<!std::is_base_of<any_time_executor_ref_base, U>::value, U>;
 public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   any_time_executor_ref_base() = delete;
   any_time_executor_ref_base(const any_time_executor_ref_base&) = default;
 
-  template <class Wrapped, TimeSender<single_tag> W = wrapped_t<Wrapped>>
+  template <class Wrapped, TimeSender<is_single<>> W = wrapped_t<Wrapped>>
     // requires TimeSenderTo<W, single<Other, E>>
   any_time_executor_ref_base(Wrapped& w) {
     // This can't be a requirement because it asks if submit(w, now(w), single<T,E>)

--- a/include/pushmi/extension_points.h
+++ b/include/pushmi/extension_points.h
@@ -254,12 +254,12 @@ PUSHMI_INLINE_VAR constexpr __adl::get_now_fn now{};
 PUSHMI_INLINE_VAR constexpr __adl::get_now_fn top{};
 
 template <class T>
-struct receiver_traits<std::promise<T>> {
-  using receiver_category = single_tag;
+struct property_set_traits<std::promise<T>> {
+  using properties = property_set<is_receiver<>, is_single<>>;
 };
 template <>
-struct receiver_traits<std::promise<void>> {
-  using receiver_category = none_tag;
+struct property_set_traits<std::promise<void>> {
+  using properties = property_set<is_receiver<>, is_none<>>;
 };
 
 } // namespace pushmi

--- a/include/pushmi/flow_single_deferred.h
+++ b/include/pushmi/flow_single_deferred.h
@@ -30,7 +30,7 @@ class flow_single_deferred<V, PE, E> {
   using wrapped_t =
     std::enable_if_t<!std::is_same<U, flow_single_deferred>::value, U>;
  public:
-  using sender_category = flow_tag;
+  using properties = property_set<is_sender<>, is_flow<>, is_single<>>;
 
   flow_single_deferred() = default;
   flow_single_deferred(flow_single_deferred&& that) noexcept
@@ -40,7 +40,7 @@ class flow_single_deferred<V, PE, E> {
   }
   template <
       class Wrapped,
-      FlowSingleSender<flow_single<V, PE, E>, any_none<PE>, V, E> W = wrapped_t<Wrapped>>
+      FlowSender<is_single<>> W = wrapped_t<Wrapped>>
   explicit flow_single_deferred(Wrapped obj) : flow_single_deferred() {
     struct s {
       static void op(data& src, data* dst) {
@@ -58,7 +58,7 @@ class flow_single_deferred<V, PE, E> {
   }
   template <
       class Wrapped,
-      FlowSingleSender<flow_single<V, PE, E>, any_none<PE>, V, E> W = wrapped_t<Wrapped>>
+      FlowSender<is_single<>> W = wrapped_t<Wrapped>>
     requires insitu<Wrapped>()
   explicit flow_single_deferred(Wrapped obj) noexcept : flow_single_deferred() {
     struct s {
@@ -101,13 +101,13 @@ class flow_single_deferred<SF> {
   SF sf_;
 
  public:
-  using sender_category = flow_tag;
+  using properties = property_set<is_sender<>, is_flow<>, is_single<>>;
 
   constexpr flow_single_deferred() = default;
   constexpr explicit flow_single_deferred(SF sf)
       : sf_(std::move(sf)) {}
 
-  template <Receiver<flow_tag> Out>
+  template <Receiver<is_flow<>> Out>
     requires Invocable<SF&, Out>
   void submit(Out out) {
     sf_(std::move(out));

--- a/include/pushmi/forwards.h
+++ b/include/pushmi/forwards.h
@@ -10,17 +10,42 @@
 
 namespace pushmi {
 
-// tag types
-struct silent_tag;
-struct none_tag;
-struct single_tag;
-struct flow_tag;
+// property_set
 
-template <class>
-struct sender_traits;
+template <class T>
+struct property_traits;
 
-template <class>
-struct receiver_traits;
+template <class T>
+struct property_set_traits;
+
+template<class... PropertyN>
+struct property_set;
+
+// trait & tag types
+template<class...TN>
+struct is_silent;
+template<class...TN>
+struct is_none;
+template<class...TN>
+struct is_single;
+template<class...TN>
+struct is_many;
+
+template<class...TN>
+struct is_flow;
+
+template<class...TN>
+struct is_receiver;
+
+template<class...TN>
+struct is_sender;
+
+template<class...TN>
+struct is_time;
+template<class...TN>
+struct is_constrained;
+
+// implementation types
 
 template <SemiMovable... TN>
 class none;
@@ -58,9 +83,3 @@ namespace aliases {
 }
 
 } // namespace pushmi
-
-#if __cpp_inline_variables >= 201606
-#define PUSHMI_INLINE_VAR inline
-#else
-#define PUSHMI_INLINE_VAR
-#endif

--- a/include/pushmi/none.h
+++ b/include/pushmi/none.h
@@ -33,7 +33,7 @@ class none<E> {
   using wrapped_t =
     std::enable_if_t<!std::is_same<U, none>::value, U>;
 public:
-  using receiver_category = none_tag;
+  using properties = property_set<is_receiver<>, is_none<>>;
 
   none() = default;
   none(none&& that) noexcept : none() {
@@ -115,7 +115,7 @@ class none<EF, DF> {
   DF df_{};
 
 public:
-  using receiver_category = none_tag;
+  using properties = property_set<is_receiver<>, is_none<>>;
 
   none() = default;
   constexpr explicit none(EF ef)
@@ -144,7 +144,7 @@ public:
   }
 };
 
-template <Receiver<none_tag> Data, class DEF, class DDF>
+template <Receiver<is_none<>> Data, class DEF, class DDF>
   requires Invocable<DDF&, Data&>
 class none<Data, DEF, DDF> {
   bool done_ = false;
@@ -154,7 +154,7 @@ class none<Data, DEF, DDF> {
   static_assert(!detail::is_v<DEF, on_value_fn>);
   static_assert(!detail::is_v<Data, single>);
 public:
-  using receiver_category = none_tag;
+  using properties = property_set<is_receiver<>, is_none<>>;
 
   constexpr explicit none(Data d) : none(std::move(d), DEF{}, DDF{}) {}
   constexpr none(Data d, DDF df)
@@ -204,23 +204,23 @@ template <class EF, class DF>
 auto make_none(EF ef, DF df) -> none<EF, DF> {
   return {std::move(ef), std::move(df)};
 }
-template <Receiver<none_tag> Data>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data>
+  requires !Receiver<Data, is_single<>>
 auto make_none(Data d) -> none<Data, passDEF, passDDF> {
   return none<Data, passDEF, passDDF>{std::move(d)};
 }
-template <Receiver<none_tag> Data, class DEF>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DEF>
+  requires !Receiver<Data, is_single<>>
 auto make_none(Data d, DEF ef) -> none<Data, DEF, passDDF> {
   return {std::move(d), std::move(ef)};
 }
-template <Receiver<none_tag> Data, class DDF>
-  requires Invocable<DDF&, Data&> && !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DDF>
+  requires Invocable<DDF&, Data&> && !Receiver<Data, is_single<>>
 auto make_none(Data d, DDF df) -> none<Data, passDEF, DDF> {
   return {std::move(d), std::move(df)};
 }
-template <Receiver<none_tag> Data, class DEF, class DDF>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DEF, class DDF>
+  requires !Receiver<Data, is_single<>>
 auto make_none(Data d, DEF ef, DDF df) -> none<Data, DEF, DDF> {
   return {std::move(d), std::move(ef), std::move(df)};
 }
@@ -241,20 +241,20 @@ template <class EF, class DF>
   requires Invocable<DF&>
 none(EF, DF) -> none<EF, DF>;
 
-template <Receiver<none_tag> Data>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data>
+  requires !Receiver<Data, is_single<>>
 none(Data) -> none<Data, passDEF, passDDF>;
 
-template <Receiver<none_tag> Data, class DEF>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DEF>
+  requires !Receiver<Data, is_single<>>
 none(Data, DEF) -> none<Data, DEF, passDDF>;
 
-template <Receiver<none_tag> Data, class DDF>
-  requires Invocable<DDF&, Data&> && !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DDF>
+  requires Invocable<DDF&, Data&> && !Receiver<Data, is_single<>>
 none(Data, DDF) -> none<Data, passDEF, DDF>;
 
-template <Receiver<none_tag> Data, class DEF, class DDF>
-  requires !Receiver<Data, single_tag>
+template <Receiver<is_none<>> Data, class DEF, class DDF>
+  requires !Receiver<Data, is_single<>>
 none(Data, DEF, DDF) -> none<Data, DEF, DDF>;
 #endif
 
@@ -283,7 +283,7 @@ struct construct_deduced<none> {
 //   return none<E>{std::move(w)};
 // }
 
-template <SenderTo<std::promise<void>, none_tag> Out>
+template <SenderTo<std::promise<void>, is_none<>> Out>
 std::future<void> future_from(Out out) {
   std::promise<void> p;
   auto result = p.get_future();

--- a/include/pushmi/properties.h
+++ b/include/pushmi/properties.h
@@ -1,0 +1,175 @@
+#pragma once
+// Copyright (c) 2018-present, Facebook, Inc.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <type_traits>
+
+namespace pushmi {
+
+// property_set implements a map of category-type to property-type.
+// for each category only one property in that category is allowed in the set.
+
+// customization point for a property with a category
+
+template <class T>
+using __property_category_t = typename T::property_category;
+
+template <class T>
+struct property_traits : property_traits<std::decay_t<T>> {
+};
+template <Decayed T>
+struct property_traits<T> {
+};
+template <Decayed T>
+  requires Valid<T, __property_category_t>
+struct property_traits<T> {
+  using property_category = __property_category_t<T>;
+};
+
+template <class T>
+using property_category_t = __property_category_t<property_traits<T>>;
+
+template<class T>
+concept bool Property = Valid<T, property_category_t>;
+
+
+// in cases where Set contains T, allow T to find itself only once
+template<class T, class... Set>
+concept bool FoundExactlyOnce = 
+  requires(T&, Set&...) {
+    ((std::is_same<T, Set>::value ? 1 : 0) + ... + 0) == 1;
+  };
+
+template<class... PropertyN>
+concept bool UniqueCategory = 
+  (Property<PropertyN> && ... && true) &&
+  requires(PropertyN&...) {
+    (FoundExactlyOnce<property_category_t<PropertyN>, property_category_t<PropertyN>...> && ... && true) == true;
+  };
+
+
+
+template<class... PropertyN>
+struct property_set {
+  static_assert((Property<PropertyN> && ... && true), "property_set only supports types that match the Property concept");
+  static_assert(UniqueCategory<PropertyN...>, "property_set has multiple properties from the same category");
+};
+
+
+
+template<class T>
+concept bool PropertySet = detail::is_v<T, property_set>;
+
+// customization point for a type with properties
+
+template <class T>
+using __properties_t = typename T::properties;
+
+template <class T>
+struct property_set_traits : property_traits<std::decay_t<T>> {
+};
+template <Decayed T>
+struct property_set_traits<T> {
+};
+template <Decayed T>
+  requires Valid<T, __properties_t>
+struct property_set_traits<T> {
+  using properties = __properties_t<T>;
+};
+
+template <class T>
+  requires PropertySet<__properties_t<property_set_traits<T>>>
+using properties_t = __properties_t<property_set_traits<T>>;
+
+template<class T>
+concept bool Properties = Valid<T, properties_t>;
+
+// insert
+// insert will replace the property in the left set with the property in the 
+// right set that matches on the category-type and add the properties from the 
+// right set that do not match on the category-type of any of the properties
+// in the left set.
+
+template<class PropertySet0, class... PropertySetN>
+struct property_set_insert;
+
+template<class... Properties0, class Property0, class... PropertyN>
+  requires Property<Property0>
+struct property_set_insert<property_set<Properties0...>, Property0, PropertyN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Properties0...>, PropertyN...>::type;
+};
+
+template<class... Properties0, class... Properties1, class... PropertySetN>
+struct property_set_insert<property_set<Properties0...>, property_set<Properties1...>, PropertySetN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Properties1...>, PropertySetN...>::type;
+};
+
+template<class... Properties0, class Property, class... PropertySetN>
+struct property_set_insert<property_set<Properties0...>, Property, PropertySetN...> {
+  using type = typename property_set_insert<property_set<Properties0..., Property>, PropertySetN...>::type;
+};
+
+template<class... Properties0>
+struct property_set_insert<property_set<Properties0...>> {
+  using type = property_set<Properties0...>;
+};
+
+template<class PS0, class PS1>
+using property_insert_t = typename property_set_insert<PS0, PS1>::type;
+
+// find property in the specified set that matches the category of the property specified.
+
+template<class PropertySet0, class Category>
+struct property_from_category;
+
+template<class Property0, class... PropertyN, Property P>
+struct property_from_category<property_set<Property0, PropertyN...>, P> {
+  using type = typename property_from_category<property_set<Property0, PropertyN...>, property_category_t<P>>::type;
+};
+
+template<class Category, Property Property0, Property... PropertyN>
+  requires !Property<Category>
+struct property_from_category<property_set<Property0, PropertyN...>, Category> {
+  using type = typename property_from_category<property_set<PropertyN...>, Category>::type;
+};
+
+template<Property Property0, Property... PropertyN>
+struct property_from_category<property_set<Property0, PropertyN...>, property_category_t<Property0>> {
+  using type = Property0;
+};
+
+template<class Category>
+struct property_from_category<property_set<>, Category> {
+};
+
+template<class PS, class C>
+using property_from_category_t = typename property_from_category<PS, C>::type;
+
+
+// query for properties on types with properties.
+
+template<class Expected, class... TN>
+struct found_base : 
+  std::integral_constant<bool, (std::is_base_of<Expected, TN>::value || ... || false)> {};
+template<class Expected, class... TN>
+constexpr bool found_base_v = found_base<Expected, TN...>::value;
+
+template<class PS, class... ExpectedN>
+struct property_query : std::false_type {};
+
+template<class PS, class... ExpectedN>
+  requires Properties<PS>
+struct property_query<PS, ExpectedN...> : property_query<properties_t<PS>, ExpectedN...> {};
+
+template<class... PropertyN, class... ExpectedN>
+  requires (Property<PropertyN> && ... && true) &&
+  (Property<ExpectedN> && ... && true)
+struct property_query<property_set<PropertyN...>, ExpectedN...> : 
+  std::integral_constant<bool, (found_base_v<ExpectedN, PropertyN...> && ... && true)> {};
+
+template<class PS, class... ExpectedN>
+inline constexpr bool property_query_v = property_query<PS, ExpectedN...>::value;
+
+} // namespace pushmi

--- a/include/pushmi/properties.h
+++ b/include/pushmi/properties.h
@@ -123,30 +123,25 @@ using property_insert_t = typename property_set_insert<PS0, PS1>::type;
 
 // find property in the specified set that matches the category of the property specified.
 
-template<class PropertySet0, class Category>
+template<class... TN>
 struct property_from_category;
 
-template<class Property0, class... PropertyN, class P>
-  requires Property<Property0> && And<Property<PropertyN>...> && Property<P>
-struct property_from_category<property_set<Property0, PropertyN...>, P> {
-  using type = typename property_from_category<property_set<Property0, PropertyN...>, property_category_t<P>>::type;
-};
+template<class PS, class P>
+  requires Properties<PS> && Property<P>
+struct property_from_category<PS, P> : property_from_category<properties_t<PS>, property_category_t<P>> {};
 
-template<class Category, class Property0, class... PropertyN>
-  requires !Property<Category> && Property<Property0> && And<Property<PropertyN>...>
-struct property_from_category<property_set<Property0, PropertyN...>, Category> {
-  using type = typename property_from_category<property_set<PropertyN...>, Category>::type;
-};
+template<class... PN, class Category>
+  requires And<Property<PN>...> && !Property<Category>
+struct property_from_category<property_set<PN...>, Category> : property_from_category<PN, property_category_t<PN>, Category>... {};
 
-template<class Property0, class... PropertyN>
-  requires Property<Property0> && And<Property<PropertyN>...>
-struct property_from_category<property_set<Property0, PropertyN...>, property_category_t<Property0>> {
-  using type = Property0;
+template<class P, class Category>
+  requires Property<P> && !Property<Category>
+struct property_from_category<P, Category, Category> {
+  using type = P;
 };
-
-template<class Category>
-struct property_from_category<property_set<>, Category> {
-};
+template<class P, class Category, class Expected>
+  requires Property<P> && !Property<Category> && !Property<Expected>
+struct property_from_category<P, Category, Expected> {};
 
 template<class PS, class C>
 using property_from_category_t = typename property_from_category<PS, C>::type;

--- a/include/pushmi/single.h
+++ b/include/pushmi/single.h
@@ -47,7 +47,7 @@ class single<V, E> {
       "Wrapped single must support E and be noexcept");
   }
 public:
-  using receiver_category = single_tag;
+  using properties = property_set<is_receiver<>, is_single<>>;
 
   single() = default;
   single(single&& that) noexcept : single() {
@@ -171,7 +171,7 @@ class single<VF, EF, DF> {
       "error function must be noexcept and support std::exception_ptr");
 
  public:
-  using receiver_category = single_tag;
+  using properties = property_set<is_receiver<>, is_single<>>;
 
   single() = default;
   constexpr explicit single(VF vf) : single(std::move(vf), EF{}, DF{}) {}
@@ -225,7 +225,7 @@ requires Invocable<DDF&, Data&> class single<Data, DVF, DEF, DDF> {
       "error function must be noexcept and support std::exception_ptr");
 
  public:
-  using receiver_category = single_tag;
+  using properties = property_set<is_receiver<>, is_single<>>;
 
   constexpr explicit single(Data d)
       : single(std::move(d), DVF{}, DEF{}, DDF{}) {}
@@ -300,34 +300,34 @@ template <class VF, class EF, class DF>
 auto make_single(VF vf, EF ef, DF df) -> single<VF, EF, DF> {
   return {std::move(vf), std::move(ef), std::move(df)};
 }
-template <Receiver<single_tag> Data>
+template <Receiver<is_single<>> Data>
 auto make_single(Data d) -> single<Data, passDVF, passDEF, passDDF> {
   return single<Data, passDVF, passDEF, passDDF>{std::move(d)};
 }
-template <Receiver<single_tag> Data, class DVF>
+template <Receiver<is_single<>> Data, class DVF>
 auto make_single(Data d, DVF vf) -> single<Data, DVF, passDEF, passDDF> {
   return {std::move(d), std::move(vf)};
 }
-template <Receiver<single_tag> Data, class... DEFN>
+template <Receiver<is_single<>> Data, class... DEFN>
 auto make_single(Data d, on_error_fn<DEFN...> ef) ->
     single<Data, passDVF, on_error_fn<DEFN...>, passDDF> {
   return {std::move(d), std::move(ef)};
 }
-template <Receiver<single_tag> Data, class DDF>
+template <Receiver<is_single<>> Data, class DDF>
   requires Invocable<DDF&, Data&>
 auto make_single(Data d, DDF df) -> single<Data, passDVF, passDEF, DDF> {
   return {std::move(d), std::move(df)};
 }
-template <Receiver<single_tag> Data, class DVF, class DEF>
+template <Receiver<is_single<>> Data, class DVF, class DEF>
 auto make_single(Data d, DVF vf, DEF ef) -> single<Data, DVF, DEF, passDDF> {
   return {std::move(d), std::move(vf), std::move(ef)};
 }
-template <Receiver<single_tag> Data, class DEF, class DDF>
+template <Receiver<is_single<>> Data, class DEF, class DDF>
   requires Invocable<DDF&, Data&>
 auto make_single(Data d, DEF ef, DDF df) -> single<Data, passDVF, DEF, DDF> {
   return {std::move(d), std::move(ef), std::move(df)};
 }
-template <Receiver<single_tag> Data, class DVF, class DEF, class DDF>
+template <Receiver<is_single<>> Data, class DVF, class DEF, class DDF>
 auto make_single(Data d, DVF vf, DEF ef, DDF df) -> single<Data, DVF, DEF, DDF> {
   return {std::move(d), std::move(vf), std::move(ef), std::move(df)};
 }
@@ -358,28 +358,28 @@ template <class VF, class EF, class DF>
   requires Invocable<DF&>
 single(VF, EF, DF) -> single<VF, EF, DF>;
 
-template <Receiver<single_tag> Data>
+template <Receiver<is_single<>> Data>
 single(Data d) -> single<Data, passDVF, passDEF, passDDF>;
 
-template <Receiver<single_tag> Data, class DVF>
+template <Receiver<is_single<>> Data, class DVF>
 single(Data d, DVF vf) -> single<Data, DVF, passDEF, passDDF>;
 
-template <Receiver<single_tag> Data, class... DEFN>
+template <Receiver<is_single<>> Data, class... DEFN>
 single(Data d, on_error_fn<DEFN...>) ->
     single<Data, passDVF, on_error_fn<DEFN...>, passDDF>;
 
-template <Receiver<single_tag> Data, class DDF>
+template <Receiver<is_single<>> Data, class DDF>
   requires Invocable<DDF&, Data&>
 single(Data d, DDF) -> single<Data, passDVF, passDEF, DDF>;
 
-template <Receiver<single_tag> Data, class DVF, class DEF>
+template <Receiver<is_single<>> Data, class DVF, class DEF>
 single(Data d, DVF vf, DEF ef) -> single<Data, DVF, DEF, passDDF>;
 
-template <Receiver<single_tag> Data, class DEF, class DDF>
+template <Receiver<is_single<>> Data, class DEF, class DDF>
   requires Invocable<DDF&, Data&>
 single(Data d, DEF, DDF) -> single<Data, passDVF, DEF, DDF>;
 
-template <Receiver<single_tag> Data, class DVF, class DEF, class DDF>
+template <Receiver<is_single<>> Data, class DVF, class DEF, class DDF>
 single(Data d, DVF vf, DEF ef, DDF df) -> single<Data, DVF, DEF, DDF>;
 #endif
 
@@ -400,7 +400,7 @@ struct construct_deduced<single> {
 //   return single<V, E>{std::move(w)};
 // }
 
-template<class T, SenderTo<std::promise<T>, single_tag> Out>
+template<class T, SenderTo<std::promise<T>, is_single<>> Out>
 std::future<T> future_from(Out singleSender) {
   std::promise<T> p;
   auto result = p.get_future();

--- a/include/pushmi/time_single_deferred.h
+++ b/include/pushmi/time_single_deferred.h
@@ -33,7 +33,7 @@ class time_single_deferred<V, E, TP> {
     std::enable_if_t<!std::is_same<U, time_single_deferred>::value, U>;
 
  public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   time_single_deferred() = default;
   time_single_deferred(time_single_deferred&& that) noexcept
@@ -41,7 +41,7 @@ class time_single_deferred<V, E, TP> {
     that.vptr_->op_(that.data_, &data_);
     std::swap(that.vptr_, vptr_);
   }
-  template <class Wrapped, Sender<single_tag> W = wrapped_t<Wrapped>>
+  template <class Wrapped, Sender<is_single<>> W = wrapped_t<Wrapped>>
     requires TimeSenderTo<W, single<V, E>>
   explicit time_single_deferred(Wrapped obj) : time_single_deferred() {
     struct s {
@@ -64,7 +64,7 @@ class time_single_deferred<V, E, TP> {
     data_.pobj_ = new Wrapped(std::move(obj));
     vptr_ = &vtbl;
   }
-  template <class Wrapped, Sender<single_tag> W = wrapped_t<Wrapped>>
+  template <class Wrapped, Sender<is_single<>> W = wrapped_t<Wrapped>>
     requires TimeSenderTo<W, single<V, E>> && insitu<Wrapped>()
   explicit time_single_deferred(Wrapped obj) noexcept : time_single_deferred() {
     struct s {
@@ -115,7 +115,7 @@ class time_single_deferred<SF, NF> {
   NF nf_{};
 
  public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   constexpr time_single_deferred() = default;
   constexpr explicit time_single_deferred(SF sf)
@@ -125,21 +125,21 @@ class time_single_deferred<SF, NF> {
   auto now() {
     return nf_();
   }
-  template <Regular TP, Receiver<single_tag> Out>
+  template <Regular TP, Receiver<is_single<>> Out>
     requires Invocable<SF&, TP, Out>
   void submit(TP tp, Out out) {
     sf_(std::move(tp), std::move(out));
   }
 };
 
-template <TimeSender<single_tag> Data, class DSF, Invocable<Data&> DNF>
+template <TimeSender<is_single<>> Data, class DSF, Invocable<Data&> DNF>
 class time_single_deferred<Data, DSF, DNF> {
   Data data_{};
   DSF sf_{};
   DNF nf_{};
 
  public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   constexpr time_single_deferred() = default;
   constexpr explicit time_single_deferred(Data data)
@@ -150,7 +150,7 @@ class time_single_deferred<Data, DSF, DNF> {
     return nf_(data_);
   }
 
-  template <class TP, Receiver<single_tag> Out>
+  template <class TP, Receiver<is_single<>> Out>
     requires Invocable<DSF&, Data&, TP, Out>
   void submit(TP tp, Out out) {
     sf_(data_, std::move(tp), std::move(out));
@@ -171,12 +171,12 @@ template <class SF, Invocable NF>
 auto make_time_single_deferred(SF sf, NF nf) -> time_single_deferred<SF, NF> {
   return {std::move(sf), std::move(nf)};
 }
-template <TimeSender<single_tag> Data, class DSF>
+template <TimeSender<is_single<>> Data, class DSF>
 auto make_time_single_deferred(Data d, DSF sf) ->
     time_single_deferred<Data, DSF, passDNF> {
   return {std::move(d), std::move(sf)};
 }
-template <TimeSender<single_tag> Data, class DSF, class DNF>
+template <TimeSender<is_single<>> Data, class DSF, class DNF>
 auto make_time_single_deferred(Data d, DSF sf, DNF nf) ->
     time_single_deferred<Data, DSF, DNF> {
   return {std::move(d), std::move(sf), std::move(nf)};
@@ -193,10 +193,10 @@ time_single_deferred(SF) -> time_single_deferred<SF, systemNowF>;
 template <class SF, Invocable NF>
 time_single_deferred(SF, NF) -> time_single_deferred<SF, NF>;
 
-template <TimeSender<single_tag> Data, class DSF>
+template <TimeSender<is_single<>> Data, class DSF>
 time_single_deferred(Data, DSF) -> time_single_deferred<Data, DSF, passDNF>;
 
-template <TimeSender<single_tag> Data, class DSF, class DNF>
+template <TimeSender<is_single<>> Data, class DSF, class DNF>
 time_single_deferred(Data, DSF, DNF) -> time_single_deferred<Data, DSF, DNF>;
 #endif
 
@@ -210,7 +210,7 @@ using any_time_single_deferred = time_single_deferred<V, E, TP>;
 //     class V,
 //     class E = std::exception_ptr,
 //     class TP = std::chrono::system_clock::time_point,
-//     TimeSenderTo<single<V, E>, single_tag> Wrapped>
+//     TimeSenderTo<single<V, E>, is_single<>> Wrapped>
 // auto erase_cast(Wrapped w) {
 //   return time_single_deferred<V, E>{std::move(w)};
 // }

--- a/include/pushmi/trampoline.h
+++ b/include/pushmi/trampoline.h
@@ -95,14 +95,14 @@ class delegator {
   using time_point = typename trampoline<E>::time_point;
 
  public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   time_point now() {
     return trampoline<E>::now();
   }
 
   template <class SingleReceiver>
-    requires Receiver<remove_cvref_t<SingleReceiver>, single_tag>
+    requires Receiver<remove_cvref_t<SingleReceiver>, is_single<>>
   void submit(time_point when, SingleReceiver&& what) {
     trampoline<E>::submit(
         ownordelegate, when, std::forward<SingleReceiver>(what));
@@ -114,7 +114,7 @@ class nester {
   using time_point = typename trampoline<E>::time_point;
 
  public:
-  using sender_category = single_tag;
+  using properties = property_set<is_time<>, is_single<>>;
 
   time_point now() {
     return trampoline<E>::now();

--- a/test/PushmiTest.cpp
+++ b/test/PushmiTest.cpp
@@ -20,13 +20,14 @@ using namespace std::literals;
 
 using namespace pushmi::aliases;
 
+
 SCENARIO( "empty can be used with tap and submit", "[empty][deferred]" ) {
 
   GIVEN( "An empty deferred" ) {
     auto e = op::empty();
     using E = decltype(e);
 
-    REQUIRE( v::SenderTo<E, v::any_none<>, v::none_tag> );
+    REQUIRE( v::SenderTo<E, v::any_none<>, v::is_none<>> );
 
     WHEN( "tap and submit are applied" ) {
       int signals = 0;
@@ -56,9 +57,10 @@ SCENARIO( "empty can be used with tap and submit", "[empty][deferred]" ) {
     auto e = op::empty<int>();
     using E = decltype(e);
 
-    REQUIRE( v::SenderTo<E, v::any_single<int>, v::single_tag> );
+    REQUIRE( v::SenderTo<E, v::any_single<int>, v::is_single<>> );
 
     WHEN( "tap and submit are applied" ) {
+      
       int signals = 0;
       e |
         op::tap(
@@ -83,7 +85,7 @@ SCENARIO( "just() can be used with transform and submit", "[just][deferred]" ) {
     auto j = op::just(20);
     using J = decltype(j);
 
-    REQUIRE( v::SenderTo<J, v::any_single<int>, v::single_tag> );
+    REQUIRE( v::SenderTo<J, v::any_single<int>, v::is_single<>> );
 
     WHEN( "transform and submit are applied" ) {
       int signals = 0;


### PR DESCRIPTION
this adds `property_set<>` as a common & user extensible tag system and updates the Concepts to use `property_set<>`.

there is a change in blocking_submit that was required to avoid an ICE.
there are two requirements commented in tap. I was unable to debug how they fail when the actual calls succeed.

todo with the property system:
allow user specified properties to be added to single<>, none<>, single_deferred, deferred, etc..
investigate need for runtime properties and non-boolean properties.