### PR TITLE
Semi example

### DIFF
--- a/examples/composition/CMakeLists.txt
+++ b/examples/composition/CMakeLists.txt
@@ -11,4 +11,10 @@ add_executable(composition_3 composition_3.cpp)
     pushmi
     examples
     Threads::Threads)
+
+add_executable(composition_4 composition_4.cpp)
+  target_link_libraries(composition_4
+    pushmi
+    examples
+    Threads::Threads)
   

--- a/examples/composition/composition_2.cpp
+++ b/examples/composition/composition_2.cpp
@@ -101,11 +101,8 @@ int main()
   sugar(cpuPool.executor(), ioPool.executor());
   pipe(cpuPool.executor(), ioPool.executor());
 
-  std::cout << "OK" << std::endl;
-
-  ioPool.stop();
-  cpuPool.stop();
-
   ioPool.wait();
   cpuPool.wait();
+
+  std::cout << "OK" << std::endl;
 }

--- a/examples/composition/composition_4.cpp
+++ b/examples/composition/composition_4.cpp
@@ -1,0 +1,42 @@
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+#include <pool.h>
+
+#include <request_via.h>
+
+#include <pushmi/o/tap.h>
+#include <pushmi/o/transform.h>
+
+using namespace pushmi::aliases;
+
+template<class Io>
+auto io_operation(Io io) {
+    return io | 
+      op::transform([](auto){ return 42; }) |
+      op::tap([](int v){ printf("io pool producing, %d\n", v); }) |
+      op::request_via();
+}
+
+int main()
+{
+  mi::pool cpuPool{std::max(1u,std::thread::hardware_concurrency())};
+  mi::pool ioPool{std::max(1u,std::thread::hardware_concurrency())};
+
+  auto io = ioPool.executor();
+  auto cpu = cpuPool.executor();
+
+  io_operation(io).via([cpu]{ return cpu; }) | 
+    op::tap([](int v){ printf("cpu pool processing, %d\n", v); }) |
+    op::submit();
+
+  ioPool.wait();
+  cpuPool.wait();
+
+  std::cout << "OK" << std::endl;
+}
+
+
+

--- a/examples/include/request_via.h
+++ b/examples/include/request_via.h
@@ -1,0 +1,45 @@
+// clang-format off
+// clang format does not support the '<>' in the lambda syntax yet.. []<>()->{}
+#pragma once
+// Copyright (c) 2018-present, Facebook, Inc.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <pushmi/single.h>
+#include <pushmi/o/submit.h>
+#include <pushmi/o/extension_operators.h>
+#include <pushmi/o/via.h>
+
+namespace pushmi {
+
+namespace detail {
+
+struct request_via_fn {
+  template<typename In>
+  struct semisender {
+      In in;
+      template<class... AN>
+      auto via(AN&&... an) {
+          return in | ::pushmi::operators::via((AN&&) an...);
+      }
+  };
+  auto operator()() const;
+};
+
+auto request_via_fn::operator()() const {
+  return constrain(lazy::Sender<_1>, [](auto in) {
+    using In = decltype(in);
+    return semisender<In>{in};
+  });
+}
+
+} // namespace detail
+
+namespace operators {
+
+PUSHMI_INLINE_VAR constexpr detail::request_via_fn request_via{}; 
+
+} // namespace operators
+
+} // namespace pushmi

--- a/examples/include/subject.h
+++ b/examples/include/subject.h
@@ -9,69 +9,6 @@
 
 namespace pushmi {
 
-template<class T>
-struct subject_shared {
-  bool done_ = false;
-  pushmi::detail::opt<T> t_;
-  std::exception_ptr ep_;
-  std::vector<any_single<T>> receivers_;
-  std::mutex lock_;
-  PUSHMI_TEMPLATE(class Out)
-    (requires Receiver<Out>)
-  void submit(Out out) {
-    std::unique_lock<std::mutex> guard(lock_);
-    if (ep_) {::pushmi::set_error(out, ep_); return;}
-    if (!!t_) {::pushmi::set_value(out, (const T&)t_); return;}
-    if (done_) {::pushmi::set_done(out); return;}
-    receivers_.push_back(any_single<T>{out});
-  }
-  PUSHMI_TEMPLATE(class V)
-    (requires SemiMovable<V>)
-  void value(V&& v) {
-    std::unique_lock<std::mutex> guard(lock_);
-    t_ = detail::as_const(v);
-    for (auto& out : receivers_) {::pushmi::set_value(out, (V&&) v);}
-    receivers_.clear();
-  }
-  PUSHMI_TEMPLATE(class E)
-    (requires SemiMovable<E>)
-  void error(E e) noexcept {
-    std::unique_lock<std::mutex> guard(lock_);
-    ep_ = e;
-    for (auto& out : receivers_) {::pushmi::set_error(out, std::move(e));}
-    receivers_.clear();
-  }
-  void done() {
-    std::unique_lock<std::mutex> guard(lock_);
-    done_ = true;
-    for (auto& out : receivers_) {::pushmi::set_done(out);}
-    receivers_.clear();
-  }
-};
-
-// need a template overload of none/deferred and the rest that stores a 'ptr' with its own lifetime management
-template<class T, class PS>
-struct subject_receiver {
-
-  using properties = property_insert_t<property_set<is_receiver<>, is_single<>>, PS>;
-
-  std::shared_ptr<subject_shared<T>> s;
-
-  PUSHMI_TEMPLATE(class V)
-    (requires SemiMovable<V>)
-  void value(V&& v) {
-    s->value((V&&) v);
-  }
-  PUSHMI_TEMPLATE(class E)
-    (requires SemiMovable<E>)
-  void error(E e) noexcept {
-    s->error(std::move(e));
-  }
-  void done() {
-    s->done();
-  }
-};
-
 template<class... TN>
 struct subject;
 
@@ -80,7 +17,68 @@ struct subject<T, PS> {
 
   using properties = property_insert_t<property_set<is_sender<>, is_single<>>, PS>;
 
-  std::shared_ptr<subject_shared<T>> s = std::make_shared<subject_shared<T>>();
+  struct subject_shared {
+    bool done_ = false;
+    pushmi::detail::opt<T> t_;
+    std::exception_ptr ep_;
+    std::vector<any_single<T>> receivers_;
+    std::mutex lock_;
+    PUSHMI_TEMPLATE(class Out)
+      (requires Receiver<Out>)
+    void submit(Out out) {
+      std::unique_lock<std::mutex> guard(lock_);
+      if (ep_) {::pushmi::set_error(out, ep_); return;}
+      if (!!t_) {::pushmi::set_value(out, (const T&)t_); return;}
+      if (done_) {::pushmi::set_done(out); return;}
+      receivers_.push_back(any_single<T>{out});
+    }
+    PUSHMI_TEMPLATE(class V)
+      (requires SemiMovable<V>)
+    void value(V&& v) {
+      std::unique_lock<std::mutex> guard(lock_);
+      t_ = detail::as_const(v);
+      for (auto& out : receivers_) {::pushmi::set_value(out, (V&&) v);}
+      receivers_.clear();
+    }
+    PUSHMI_TEMPLATE(class E)
+      (requires SemiMovable<E>)
+    void error(E e) noexcept {
+      std::unique_lock<std::mutex> guard(lock_);
+      ep_ = e;
+      for (auto& out : receivers_) {::pushmi::set_error(out, std::move(e));}
+      receivers_.clear();
+    }
+    void done() {
+      std::unique_lock<std::mutex> guard(lock_);
+      done_ = true;
+      for (auto& out : receivers_) {::pushmi::set_done(out);}
+      receivers_.clear();
+    }
+  };
+
+  // need a template overload of none/deferred and the rest that stores a 'ptr' with its own lifetime management
+  struct subject_receiver {
+
+    using properties = property_insert_t<property_set<is_receiver<>, is_single<>>, PS>;
+
+    std::shared_ptr<subject_shared> s;
+
+    PUSHMI_TEMPLATE(class V)
+      (requires SemiMovable<V>)
+    void value(V&& v) {
+      s->value((V&&) v);
+    }
+    PUSHMI_TEMPLATE(class E)
+      (requires SemiMovable<E>)
+    void error(E e) noexcept {
+      s->error(std::move(e));
+    }
+    void done() {
+      s->done();
+    }
+  };
+
+  std::shared_ptr<subject_shared> s = std::make_shared<subject_shared>();
 
   PUSHMI_TEMPLATE(class Out)
     (requires Receiver<Out>)
@@ -89,7 +87,7 @@ struct subject<T, PS> {
   }
 
   auto receiver() {
-    return detail::out_from_fn<subject>{}(subject_receiver<T, PS>{s});
+    return detail::out_from_fn<subject>{}(subject_receiver{s});
   }
 };
 


### PR DESCRIPTION
add request_via() operator that returns a type that only has a via() member function. via() must be called with an executor factory and via() returns a sender that can be used generically.

This is an example of how SemiFuture functionality is composed in the pushmi model.