### PR TITLE
Twoway and then

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "external/executors-impl"]
 	path = external/executors-impl
 	url = https://github.com/executors/executors-impl.git
+[submodule "external/futures-impl"]
+	path = external/futures-impl
+	url = https://github.com/executors/futures-impl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,13 @@ target_include_directories(pushmi INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/meta/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/executors-impl/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/futures-impl/future-executor-interaction/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/networking-ts-impl/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/Catch2/single_include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/meta>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/executors>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/futures>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/net>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/Catch2>)
 target_compile_features(pushmi INTERFACE cxx_std_14)
@@ -36,6 +38,9 @@ install(
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/executors-impl/include/
     DESTINATION include/executors)
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/futures-impl/future-executor-interaction/include/
+    DESTINATION include/futures)
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/networking-ts-impl/include/
     DESTINATION include/net)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(examples INTERFACE)
 target_include_directories(examples INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
+add_subdirectory(twoway_execute)
+add_subdirectory(then_execute)
 add_subdirectory(composition)
 add_subdirectory(for_each)
 add_subdirectory(reduce)

--- a/examples/for_each/for_each_2.cpp
+++ b/examples/for_each/for_each_2.cpp
@@ -93,6 +93,5 @@ int main()
 
   std::cout << "OK" << std::endl;
 
-  p.stop();
   p.wait();
 }

--- a/examples/reduce/reduce_2.cpp
+++ b/examples/reduce/reduce_2.cpp
@@ -94,6 +94,5 @@ int main()
 
   std::cout << "OK" << std::endl;
 
-  p.stop();
   p.wait();
 }

--- a/examples/then_execute/CMakeLists.txt
+++ b/examples/then_execute/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+
+add_executable(then_execute_2 then_execute_2.cpp)
+target_link_libraries(then_execute_2
+  pushmi
+  examples
+  Threads::Threads)
+  

--- a/examples/then_execute/then_execute_2.cpp
+++ b/examples/then_execute/then_execute_2.cpp
@@ -1,0 +1,106 @@
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+#include <memory>
+#include <utility>
+#include <atomic>
+#include <thread>
+#include <functional>
+#include <futures.h>
+#include <futures_static_thread_pool.h>
+
+#include <pool.h>
+
+#include <request_via.h>
+#include <share.h>
+
+#include <pushmi/deferred.h>
+#include <pushmi/single_deferred.h>
+#include <pushmi/o/just.h>
+#include <pushmi/o/transform.h>
+
+using namespace pushmi::aliases;
+
+struct inline_executor
+{
+public:
+  friend bool operator==(
+    const inline_executor&, const inline_executor&) noexcept { return true; }
+  friend bool operator!=(
+    const inline_executor&, const inline_executor&) noexcept { return false; }
+  template<class Function>
+  void execute(Function f) const noexcept { f(); }
+  constexpr bool query(std::experimental::execution::oneway_t) { return true; }
+  constexpr bool query(std::experimental::execution::twoway_t) { return false; }
+  constexpr bool query(std::experimental::execution::single_t) { return true; }
+};
+
+namespace p1054 {
+// A promise refers to a promise and is associated with a future, 
+// either through type-erasure or through construction of an 
+// underlying promise with an overload of make_promise_contract().
+
+// make_promise_contract() cannot be written to produce a lazy future.
+// the promise has to exist prior to .then() getting a continuation.
+// there must be a shared allocation to connect the promise and future.
+template <class T, class Executor>
+std::pair<std::experimental::standard_promise<T>, std::experimental::standard_future<T, std::decay_t<Executor>>>
+make_promise_contract(const Executor& e) {
+    std::experimental::standard_promise<T> promise;
+    auto ex = e;
+    return {promise, promise.get_future(std::move(ex))};
+}
+
+template<class Executor, class Function, class Future>
+    std::experimental::standard_future<
+      std::result_of_t<Function(std::decay_t<typename std::decay_t<Future>::value_type>&&)>, std::decay_t<Executor>>
+    then_execute(Executor&& e, Function&& f, Future&& pred) {
+      using V = std::decay_t<typename std::decay_t<Future>::value_type>;
+      using T = std::result_of_t<Function(V&&)>;
+      auto pc = make_promise_contract<T>(e);
+      auto p = std::get<0>(pc);
+      auto r = std::get<1>(pc);
+      ((Future&&)pred).then([e, p, f](V v) mutable {
+        e.execute([p, f, v]() mutable {
+           p.set_value(f(v));
+        });
+        return 0;
+      });
+      return r;
+    }
+
+}
+
+namespace p1055 {
+
+template<class Executor, class Function, class Future>
+auto then_execute(Executor&& e, Function&& f, Future&& pred) {
+    return pred | op::via([e](){return e;}) | op::transform([f](auto v){return f(v);});
+}
+
+
+}
+
+int main()
+{
+  mi::pool p{std::max(1u,std::thread::hardware_concurrency())};
+
+  std::experimental::futures_static_thread_pool sp{std::max(1u,std::thread::hardware_concurrency())};
+
+  auto pc = p1054::make_promise_contract<int>(inline_executor{});
+  auto& pr = std::get<0>(pc);
+  auto& r = std::get<1>(pc);
+  auto f = p1054::then_execute(sp.executor(), [](int v){return v*2;}, std::move(r));
+  pr.set_value(42);
+  f.get();
+
+  p1055::then_execute(p.executor(), [](int v){return v*2;}, op::just(21)) | op::get<int>;
+
+  sp.wait();
+  p.wait();
+
+  std::cout << "OK" << std::endl;
+}
+

--- a/examples/twoway_execute/CMakeLists.txt
+++ b/examples/twoway_execute/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+
+add_executable(twoway_execute_2 twoway_execute_2.cpp)
+target_link_libraries(twoway_execute_2
+  pushmi
+  examples
+  Threads::Threads)
+  

--- a/examples/twoway_execute/twoway_execute_2.cpp
+++ b/examples/twoway_execute/twoway_execute_2.cpp
@@ -1,0 +1,75 @@
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+#include <memory>
+#include <utility>
+#include <atomic>
+#include <thread>
+#include <functional>
+#include <futures.h>
+
+#include <pool.h>
+
+#include <request_via.h>
+#include <share.h>
+
+#include <pushmi/deferred.h>
+#include <pushmi/single_deferred.h>
+#include <pushmi/o/transform.h>
+
+using namespace pushmi::aliases;
+
+namespace p1054 {
+// A promise refers to a promise and is associated with a future, 
+// either through type-erasure or through construction of an 
+// underlying promise with an overload of make_promise_contract().
+
+// make_promise_contract() cannot be written to produce a lazy future.
+// the promise has to exist prior to .then() getting a continuation.
+// there must be a shared allocation to connect the promise and future.
+template <class T, class Executor>
+std::pair<std::experimental::standard_promise<T>, std::experimental::standard_future<T, std::decay_t<Executor>>>
+make_promise_contract(const Executor& e) {
+    std::experimental::standard_promise<T> promise;
+    auto ex = e;
+    return {promise, promise.get_future(std::move(ex))};
+}
+
+template<class Executor, class Function>
+    std::experimental::standard_future<std::result_of_t<std::decay_t<Function>()>, std::decay_t<Executor>>
+    twoway_execute(Executor&& e, Function&& f) {
+      using T = std::result_of_t<std::decay_t<Function>()>;
+      auto pc = make_promise_contract<T>(e);
+      auto p = std::get<0>(pc);
+      auto r = std::get<1>(pc);
+      e.execute([p, f]() mutable {p.set_value(f());});
+      return r;
+    }
+}
+
+namespace p1055 {
+
+template<class Executor, class Function>
+auto twoway_execute(Executor&& e, Function&& f) {
+  return e | op::transform([f](auto){return f();});
+}
+
+}
+
+int main()
+{
+  mi::pool p{std::max(1u,std::thread::hardware_concurrency())};
+
+  std::experimental::static_thread_pool sp{std::max(1u,std::thread::hardware_concurrency())};
+
+  p1054::twoway_execute(sp.executor(), [](){return 42;}).get();
+
+  p1055::twoway_execute(p.executor(), [](){return 42;}) | op::get<int>;
+
+  sp.wait();
+  p.wait();
+
+  std::cout << "OK" << std::endl;
+}


### PR DESCRIPTION
this adds examples of the twoway and then execute functions as free functions in terms of oneway execute.

each example has a p1054 version and a p1055 version for contrast

## observations:

 - then_execute is a particularly poor way to chain work together, it imposes a lot of overhead, even with p1055.
 - make_promise_contract() cannot be implemented to return a lazy future.
