### PR TITLE
Use real concepts when they are available

### DIFF
--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -350,9 +350,9 @@ PUSHMI_CONCEPT_DEF(
 );
 
 template <class D>
-using time_point_t =
-  std::enable_if_t<TimeSender<D>, decltype(::pushmi::now(std::declval<D&>()))>;
-
+PUSHMI_PP_CONSTRAINED_USING(
+  TimeSender<D>,
+  time_point_t =, decltype(::pushmi::now(std::declval<D&>())));
 
 // this is a more general form where the constraint could be time or priority
 // enum or any other ordering constraint value-type.
@@ -386,9 +386,8 @@ PUSHMI_CONCEPT_DEF(
 );
 
 template <class D>
-using constraint_t =
-  std::enable_if_t<
-    ConstrainedSender<D>,
-    decltype(::pushmi::top(std::declval<D&>()))>;
+PUSHMI_PP_CONSTRAINED_USING(
+  ConstrainedSender<D>,
+  constraint_t =, decltype(::pushmi::top(std::declval<D&>())));
 
 } // namespace pushmi

--- a/include/pushmi/o/defer.h
+++ b/include/pushmi/o/defer.h
@@ -7,6 +7,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "../single.h"
+#include "../single_deferred.h"
 #include "submit.h"
 #include "extension_operators.h"
 

--- a/include/pushmi/properties.h
+++ b/include/pushmi/properties.h
@@ -161,14 +161,16 @@ struct property_query_impl :
   meta::and_c<decltype(property_query_fn<ExpectedN>((properties_t<PS>*)nullptr))::value...> {};
 } //namespace detail
 
-template<PUSHMI_TYPE_CONSTRAINT(Properties) PS, PUSHMI_TYPE_CONSTRAINT(Property)... ExpectedN>
+//template<PUSHMI_TYPE_CONSTRAINT(Properties) PS, PUSHMI_TYPE_CONSTRAINT(Property)... ExpectedN>
+template<class PS, class... ExpectedN>
 struct property_query
   : meta::if_c<
       Properties<PS> && And<Property<ExpectedN>...>,
       detail::property_query_impl<PS, ExpectedN...>,
       std::false_type> {};
 
-template<PUSHMI_TYPE_CONSTRAINT(Properties) PS, PUSHMI_TYPE_CONSTRAINT(Property)... ExpectedN>
+//template<PUSHMI_TYPE_CONSTRAINT(Properties) PS, PUSHMI_TYPE_CONSTRAINT(Property)... ExpectedN>
+template<class PS, class... ExpectedN>
 PUSHMI_INLINE_VAR constexpr bool property_query_v = property_query<PS, ExpectedN...>::value;
 
 } // namespace pushmi


### PR DESCRIPTION
With this change, pushmi uses real concepts when compiled on gcc with -fconcepts.