### PR TITLE
Increase required CMake version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.8)
 
 project(pushmi-project CXX)
 


### PR DESCRIPTION
pushmi uses the CMake `cxx_std_XX` compile features, [which were introduced in CMake 3.7](https://cmake.org/cmake/help/v3.8/release/3.8.html#c-c). However, pushmi currently only requires CMake version 3.7. So, if you happen to be using CMake version 3.7, running CMake fails with a cryptic error:

```
$ cmake --version
cmake version 3.7.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).

$ /home/wash/install/nvidia/cuda-9.2.88/bin/nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2018 NVIDIA Corporation
Built on Wed_Apr_11_23:16:29_CDT_2018
Cuda compilation tools, release 9.2, V9.2.88

$ g++ --version
g++ (Debian 6.4.0-12) 6.4.0 20180123
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ git rev-parse HEAD
cedca49cdc60413c35f64710eb5ea3987111b380

$ ls
buildSingleHeader.cmake  CMakeLists.txt  CODE_OF_CONDUCT.md  CONTRIBUTING.md  examples  external  include  ISSUES  LICENSE  Readme.md  TARGETS  test

$ mkdir build

$ cd build

$ cmake -DCMAKE_CXX_COMPILER=/home/wash/install/nvidia/cuda-9.2.88/bin/nvcc ..
-- The CXX compiler identification is GNU 6.4.0
-- Check for working CXX compiler: /home/wash/install/nvidia/cuda-9.2.88/bin/nvcc
-- Check for working CXX compiler: /home/wash/install/nvidia/cuda-9.2.88/bin/nvcc -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - failed
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE  
-- Configuring done
CMake Error in examples/twoway_execute/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "twoway_execute_2".


CMake Error in examples/then_execute/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "then_execute_2".


CMake Error in examples/composition/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "composition_3".


CMake Error in examples/composition/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "composition_2".


CMake Error in examples/composition/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "composition_4".


CMake Error in examples/for_each/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "for_each_3".


CMake Error in examples/for_each/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "for_each_2".


CMake Error in examples/reduce/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "reduce_3".


CMake Error in examples/reduce/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "reduce_2".


CMake Error in test/CMakeLists.txt:
  Specified unknown feature "cxx_std_14" for target "PushmiTest".


-- Generating done
-- Build files have been written to: /home/wash/development/iso-c++/pushmi/build
```

This PR increases the minimum CMake version to 3.8.
