### PR TITLE
Async fork/join

### DIFF
--- a/include/pushmi/o/async.h
+++ b/include/pushmi/o/async.h
@@ -1,0 +1,251 @@
+#pragma once
+// Copyright (c) 2018-present, Facebook, Inc.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "../piping.h"
+#include "../executor.h"
+#include "extension_operators.h"
+
+namespace pushmi {
+
+namespace detail {
+
+template<class Executor, class Out>
+struct via_fn_data : public Out {
+  Executor exec;
+
+  via_fn_data(Out out, Executor exec) :
+    Out(std::move(out)), exec(std::move(exec)) {}
+};
+
+template<class Out, class Executor>
+auto make_via_fn_data(Out out, Executor ex) -> via_fn_data<Executor, Out> {
+  return {std::move(out), std::move(ex)};
+}
+
+struct via_fn {
+  PUSHMI_TEMPLATE(class ExecutorFactory)
+    (requires Invocable<ExecutorFactory&>)
+  auto operator()(ExecutorFactory ef) const {
+    return constrain(lazy::Sender<_1>, [ef = std::move(ef)](auto in) {
+      using In = decltype(in);
+      return ::pushmi::detail::deferred_from<In, single<>>(
+        std::move(in),
+        ::pushmi::detail::submit_transform_out<In>(
+          constrain(lazy::Receiver<_1>, [ef](auto out) {
+            using Out = decltype(out);
+            auto exec = ef();
+            return ::pushmi::detail::out_from_fn<In>()(
+              make_via_fn_data(std::move(out), std::move(exec)),
+              // copy 'f' to allow multiple calls to submit
+              ::pushmi::on_value([](auto& data, auto&& v) {
+                using V = decltype(v);
+                ::pushmi::submit(
+                  data.exec,
+                  ::pushmi::now(data.exec),
+                  ::pushmi::make_single(
+                    [v = (V&&)v, out = std::move(static_cast<Out&>(data))](auto) mutable {
+                      ::pushmi::set_value(out, std::move(v));
+                    }
+                  )
+                );
+              }),
+              ::pushmi::on_error([](auto& data, auto e) noexcept {
+                ::pushmi::submit(
+                  data.exec,
+                  ::pushmi::now(data.exec),
+                  ::pushmi::make_single(
+                    [e = std::move(e), out = std::move(static_cast<Out&>(data))](auto) mutable {
+                      ::pushmi::set_error(out, std::move(e));
+                    }
+                  )
+                );
+              }),
+              ::pushmi::on_done([](auto& data){
+                ::pushmi::submit(
+                  data.exec,
+                  ::pushmi::now(data.exec),
+                  ::pushmi::make_single(
+                    [out = std::move(static_cast<Out&>(data))](auto) mutable {
+                      ::pushmi::set_done(out);
+                    }
+                  )
+                );
+              })
+            );
+          })
+        )
+      );
+    });
+  }
+};
+
+} // namespace detail
+
+namespace operators {
+PUSHMI_INLINE_VAR constexpr detail::via_fn via{};
+} // namespace operators
+
+#if 0
+
+namespace detail {
+
+template <class ExecutorFactory>
+class fsdvia {
+  using executor_factory_type = std::decay_t<ExecutorFactory>;
+
+  executor_factory_type factory_;
+
+  template <class In>
+  class start_via {
+    using in_type = std::decay_t<In>;
+
+    executor_factory_type factory_;
+    in_type in_;
+
+    template <class Out, class Executor>
+    class out_via {
+      using out_type = std::decay_t<Out>;
+      using executor_type = std::decay_t<Executor>;
+
+      struct shared_type {
+        shared_type(out_type&& out) : out_(std::move(out)), stopped_(false) {}
+        out_type out_;
+        std::atomic_bool stopped_;
+      };
+
+      template <class Producer>
+      struct producer_proxy {
+        RefWrapper<Producer> up_;
+        std::shared_ptr<shared_type> shared_;
+
+        producer_proxy(RefWrapper<Producer> p, std::shared_ptr<shared_type> s)
+            : up_(std::move(p)), shared_(std::move(s)) {}
+
+        template <class V>
+        void value(V v) {
+          if (!!shared_->stopped_.exchange(true)) {
+            return;
+          }
+          up_.get().value(std::move(v));
+        }
+
+        template <class E>
+        void error(E e) {
+          if (!!shared_->stopped_.exchange(true)) {
+            return;
+          }
+          up_.get().error(std::move(e));
+        }
+      };
+
+      bool done_;
+      std::shared_ptr<shared_type> shared_;
+      executor_type exec_;
+      std::shared_ptr<AnyNone<>> upProxy_;
+
+     public:
+      explicit out_via(out_type&& out, executor_type&& exec)
+          : done_(false),
+            shared_(std::make_shared<shared_type>(std::move(out))),
+            exec_(std::move(exec)),
+            upProxy_() {}
+
+      template <class T>
+      void value(T t) {
+        if (done_ || shared_->stopped_) {
+          done_ = true;
+          return;
+        }
+        if (!upProxy_) {
+          std::abort();
+        }
+        done_ = true;
+        exec_ | execute([t = std::move(t), shared = shared_](auto) mutable {
+          shared->out_.value(std::move(t));
+        });
+      }
+
+      template <class E>
+      void error(E e) {
+        if (done_ || shared_->stopped_) {
+          done_ = true;
+          return;
+        }
+        if (!upProxy_) {
+          std::abort();
+        }
+        done_ = true;
+        exec_ | execute([e = std::move(e), shared = shared_](auto) mutable {
+          shared->out_.error(std::move(e));
+        });
+      }
+
+      void stopping() {
+        if (done_) {
+          return;
+        }
+        if (!upProxy_) {
+          std::abort();
+        }
+        done_ = true;
+        if (!shared_->stopped_.exchange(true)) {
+          exec_ |
+              // must keep out and upProxy alive until out is notified that it
+              // is unsafe
+              execute([shared = shared_](auto) mutable {
+                shared->out_.stopping();
+              });
+        }
+      }
+
+      template <class Producer>
+      void starting(RefWrapper<Producer> up) {
+        if (!!upProxy_) {
+          std::abort();
+        }
+        upProxy_ = std::make_shared<AnyNone<>>(AnyNone<>{
+            producer_proxy<Producer>{std::move(up), shared_}});
+        // must keep out and upProxy alive until out is notified that it is
+        // starting
+        exec_ | execute([shared = shared_, upProxy = upProxy_](auto) mutable {
+          shared->out_.starting(wrap_ref(*upProxy));
+        });
+      }
+    };
+
+   public:
+    start_via(executor_factory_type&& ef, in_type&& in)
+        : factory_(ef), in_(in) {}
+
+    template <class Out>
+    auto then(Out out) {
+      auto exec = factory_();
+      in_.then(out_via<Out, decltype(exec)>{std::move(out), std::move(exec)});
+    }
+  };
+
+ public:
+  explicit fsdvia(executor_factory_type&& ef) : factory_(std::move(ef)) {}
+
+  template <class In>
+  auto operator()(In in) {
+    return start_via<In>{std::move(factory_), std::move(in)};
+  }
+};
+
+} // namespace detail
+
+namespace fsd {
+
+template <class ExecutorFactory>
+auto via(ExecutorFactory factory) {
+  return detail::fsdvia<ExecutorFactory>{std::move(factory)};
+}
+
+} // namespace fsd
+#endif
+
+} // namespace pushmi

--- a/include/pushmi/o/async.h
+++ b/include/pushmi/o/async.h
@@ -9,243 +9,179 @@
 #include "extension_operators.h"
 
 namespace pushmi {
-
 namespace detail {
 
-template<class Executor, class Out>
-struct via_fn_data : public Out {
-  Executor exec;
+  template<class ValueType, class ExecutorType>
+  struct AsyncToken {
+  public:
+    struct Data {
+      Data(ValueType v) : v_(std::move(v)) {}
+      ValueType v_;
+      std::condition_variable cv_;
+      std::mutex cvm_;
+      bool flag_ = false;
+    };
 
-  via_fn_data(Out out, Executor exec) :
-    Out(std::move(out)), exec(std::move(exec)) {}
-};
+    AsyncToken(ExecutorType e, ValueType v) :
+      e_{std::move(e)}, dataPtr_{std::make_shared<Data>(std::move(v))} {}
 
-template<class Out, class Executor>
-auto make_via_fn_data(Out out, Executor ex) -> via_fn_data<Executor, Out> {
-  return {std::move(out), std::move(ex)};
-}
+    ExecutorType e_;
+    std::shared_ptr<Data> dataPtr_;
+  };
 
-struct via_fn {
-  PUSHMI_TEMPLATE(class ExecutorFactory)
-    (requires Invocable<ExecutorFactory&>)
-  auto operator()(ExecutorFactory ef) const {
-    return constrain(lazy::Sender<_1>, [ef = std::move(ef)](auto in) {
-      using In = decltype(in);
-      return ::pushmi::detail::deferred_from<In, single<>>(
-        std::move(in),
-        ::pushmi::detail::submit_transform_out<In>(
-          constrain(lazy::Receiver<_1>, [ef](auto out) {
-            using Out = decltype(out);
-            auto exec = ef();
-            return ::pushmi::detail::out_from_fn<In>()(
-              make_via_fn_data(std::move(out), std::move(exec)),
-              // copy 'f' to allow multiple calls to submit
-              ::pushmi::on_value([](auto& data, auto&& v) {
-                using V = decltype(v);
-                ::pushmi::submit(
-                  data.exec,
-                  ::pushmi::now(data.exec),
-                  ::pushmi::make_single(
-                    [v = (V&&)v, out = std::move(static_cast<Out&>(data))](auto) mutable {
-                      ::pushmi::set_value(out, std::move(v));
-                    }
-                  )
-                );
-              }),
-              ::pushmi::on_error([](auto& data, auto e) noexcept {
-                ::pushmi::submit(
-                  data.exec,
-                  ::pushmi::now(data.exec),
-                  ::pushmi::make_single(
-                    [e = std::move(e), out = std::move(static_cast<Out&>(data))](auto) mutable {
-                      ::pushmi::set_error(out, std::move(e));
-                    }
-                  )
-                );
-              }),
-              ::pushmi::on_done([](auto& data){
-                ::pushmi::submit(
-                  data.exec,
-                  ::pushmi::now(data.exec),
-                  ::pushmi::make_single(
-                    [out = std::move(static_cast<Out&>(data))](auto) mutable {
-                      ::pushmi::set_done(out);
-                    }
-                  )
-                );
-              })
-            );
-          })
-        )
-      );
-    });
+  template<class Executor, class Out>
+  struct async_fork_fn_data : public Out {
+    Executor exec;
+
+    async_fork_fn_data(Out out, Executor exec) :
+      Out(std::move(out)), exec(std::move(exec)) {}
+  };
+
+  template<class Out, class Executor>
+  auto make_async_fork_fn_data(Out out, Executor ex) -> async_fork_fn_data<Executor, Out> {
+    return {std::move(out), std::move(ex)};
   }
-};
+
+  struct async_fork_fn {
+    PUSHMI_TEMPLATE(class ExecutorFactory)
+      (requires Invocable<ExecutorFactory&>)
+    auto operator()(ExecutorFactory ef) const {
+      return constrain(lazy::Sender<_1>, [ef = std::move(ef)](auto in) {
+        using In = decltype(in);
+        return ::pushmi::detail::deferred_from<In, single<>>(
+          std::move(in),
+          ::pushmi::detail::submit_transform_out<In>(
+            constrain(lazy::Receiver<_1>, [ef](auto out) {
+              using Out = decltype(out);
+              auto exec = ef();
+              return ::pushmi::detail::out_from_fn<In>()(
+                make_async_fork_fn_data(std::move(out), std::move(exec)),
+                // copy 'f' to allow multiple calls to submit
+                ::pushmi::on_value([](auto& data, auto&& v) {
+                  using V = decltype(v);
+                  auto exec = data.exec;
+                  ::pushmi::submit(
+                    exec,
+                    ::pushmi::now(exec),
+                    ::pushmi::make_single(
+                      [v = (V&&)v, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
+                        // Token hard coded for this executor type at the moment
+                        auto token = AsyncToken<
+                            std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
+                          exec, std::forward<decltype(v)>(v)};
+                        token.dataPtr_->flag_ = true;
+                        ::pushmi::set_value(out, std::move(token));
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_error([](auto& data, auto e) noexcept {
+                  ::pushmi::submit(
+                    data.exec,
+                    ::pushmi::now(data.exec),
+                    ::pushmi::make_single(
+                      [e = std::move(e), out = std::move(static_cast<Out&>(data))](auto) mutable {
+                        ::pushmi::set_error(out, std::move(e));
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_done([](auto& data){
+                  ::pushmi::submit(
+                    data.exec,
+                    ::pushmi::now(data.exec),
+                    ::pushmi::make_single(
+                      [out = std::move(static_cast<Out&>(data))](auto) mutable {
+                        ::pushmi::set_done(out);
+                      }
+                    )
+                  );
+                })
+              );
+            })
+          )
+        );
+      });
+    }
+  };
+
+  template<class Out>
+  struct async_join_fn_data : public Out {
+    async_join_fn_data(Out out) :
+      Out(std::move(out)) {}
+  };
+
+  template<class Out>
+  auto make_async_join_fn_data(Out out) -> async_join_fn_data<Out> {
+    return {std::move(out)};
+  }
+
+  struct async_join_fn {
+    auto operator()() const {
+      return constrain(lazy::Sender<_1>, [](auto in) {
+        using In = decltype(in);
+        return ::pushmi::detail::deferred_from<In, single<>>(
+          std::move(in),
+          ::pushmi::detail::submit_transform_out<In>(
+            constrain(lazy::Receiver<_1>, [](auto out) {
+              using Out = decltype(out);
+              return ::pushmi::detail::out_from_fn<In>()(
+                make_async_join_fn_data(std::move(out)),
+                // copy 'f' to allow multiple calls to submit
+                ::pushmi::on_value([](auto& data, auto&& asyncToken) {
+                  // Async version that does not - why not?
+                  using V = decltype(asyncToken);
+                  auto exec = asyncToken.e_;
+                  ::pushmi::submit(
+                    exec,
+                    ::pushmi::now(exec),
+                    ::pushmi::make_single(
+                      [asyncToken, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
+                        // Token hard coded for this executor type at the moment
+                        std::thread t([
+                           exec,
+                           asyncToken,
+                           out]() mutable {
+                          std::unique_lock<std::mutex> lk(asyncToken.dataPtr_->cvm_);
+                          if(!asyncToken.dataPtr_->flag_) {
+                            asyncToken.dataPtr_->cv_.wait(
+                              lk, [&](){return asyncToken.dataPtr_->flag_;});
+                          }
+                          ::pushmi::submit(
+                            exec,
+                            ::pushmi::now(exec),
+                            ::pushmi::make_single(
+                              [asyncToken, out, exec](auto) mutable {
+                                // Token hard coded for this executor type at the moment
+                                ::pushmi::set_value(out, std::move(asyncToken.dataPtr_->v_));
+                              }
+                            ));
+                        });
+                        t.detach();
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_error([](auto& data, auto e) noexcept {
+                  auto out = std::move(static_cast<Out&>(data));
+                  ::pushmi::set_error(out, std::move(e));
+                }),
+                ::pushmi::on_done([](auto& data){
+                  auto out = std::move(static_cast<Out&>(data));
+                  ::pushmi::set_done(out);
+                })
+              );
+            })
+          )
+        );
+      });
+    }
+  };
 
 } // namespace detail
 
 namespace operators {
-PUSHMI_INLINE_VAR constexpr detail::via_fn via{};
+PUSHMI_INLINE_VAR constexpr detail::async_join_fn async_join{};
+PUSHMI_INLINE_VAR constexpr detail::async_fork_fn async_fork{};
 } // namespace operators
-
-#if 0
-
-namespace detail {
-
-template <class ExecutorFactory>
-class fsdvia {
-  using executor_factory_type = std::decay_t<ExecutorFactory>;
-
-  executor_factory_type factory_;
-
-  template <class In>
-  class start_via {
-    using in_type = std::decay_t<In>;
-
-    executor_factory_type factory_;
-    in_type in_;
-
-    template <class Out, class Executor>
-    class out_via {
-      using out_type = std::decay_t<Out>;
-      using executor_type = std::decay_t<Executor>;
-
-      struct shared_type {
-        shared_type(out_type&& out) : out_(std::move(out)), stopped_(false) {}
-        out_type out_;
-        std::atomic_bool stopped_;
-      };
-
-      template <class Producer>
-      struct producer_proxy {
-        RefWrapper<Producer> up_;
-        std::shared_ptr<shared_type> shared_;
-
-        producer_proxy(RefWrapper<Producer> p, std::shared_ptr<shared_type> s)
-            : up_(std::move(p)), shared_(std::move(s)) {}
-
-        template <class V>
-        void value(V v) {
-          if (!!shared_->stopped_.exchange(true)) {
-            return;
-          }
-          up_.get().value(std::move(v));
-        }
-
-        template <class E>
-        void error(E e) {
-          if (!!shared_->stopped_.exchange(true)) {
-            return;
-          }
-          up_.get().error(std::move(e));
-        }
-      };
-
-      bool done_;
-      std::shared_ptr<shared_type> shared_;
-      executor_type exec_;
-      std::shared_ptr<AnyNone<>> upProxy_;
-
-     public:
-      explicit out_via(out_type&& out, executor_type&& exec)
-          : done_(false),
-            shared_(std::make_shared<shared_type>(std::move(out))),
-            exec_(std::move(exec)),
-            upProxy_() {}
-
-      template <class T>
-      void value(T t) {
-        if (done_ || shared_->stopped_) {
-          done_ = true;
-          return;
-        }
-        if (!upProxy_) {
-          std::abort();
-        }
-        done_ = true;
-        exec_ | execute([t = std::move(t), shared = shared_](auto) mutable {
-          shared->out_.value(std::move(t));
-        });
-      }
-
-      template <class E>
-      void error(E e) {
-        if (done_ || shared_->stopped_) {
-          done_ = true;
-          return;
-        }
-        if (!upProxy_) {
-          std::abort();
-        }
-        done_ = true;
-        exec_ | execute([e = std::move(e), shared = shared_](auto) mutable {
-          shared->out_.error(std::move(e));
-        });
-      }
-
-      void stopping() {
-        if (done_) {
-          return;
-        }
-        if (!upProxy_) {
-          std::abort();
-        }
-        done_ = true;
-        if (!shared_->stopped_.exchange(true)) {
-          exec_ |
-              // must keep out and upProxy alive until out is notified that it
-              // is unsafe
-              execute([shared = shared_](auto) mutable {
-                shared->out_.stopping();
-              });
-        }
-      }
-
-      template <class Producer>
-      void starting(RefWrapper<Producer> up) {
-        if (!!upProxy_) {
-          std::abort();
-        }
-        upProxy_ = std::make_shared<AnyNone<>>(AnyNone<>{
-            producer_proxy<Producer>{std::move(up), shared_}});
-        // must keep out and upProxy alive until out is notified that it is
-        // starting
-        exec_ | execute([shared = shared_, upProxy = upProxy_](auto) mutable {
-          shared->out_.starting(wrap_ref(*upProxy));
-        });
-      }
-    };
-
-   public:
-    start_via(executor_factory_type&& ef, in_type&& in)
-        : factory_(ef), in_(in) {}
-
-    template <class Out>
-    auto then(Out out) {
-      auto exec = factory_();
-      in_.then(out_via<Out, decltype(exec)>{std::move(out), std::move(exec)});
-    }
-  };
-
- public:
-  explicit fsdvia(executor_factory_type&& ef) : factory_(std::move(ef)) {}
-
-  template <class In>
-  auto operator()(In in) {
-    return start_via<In>{std::move(factory_), std::move(in)};
-  }
-};
-
-} // namespace detail
-
-namespace fsd {
-
-template <class ExecutorFactory>
-auto via(ExecutorFactory factory) {
-  return detail::fsdvia<ExecutorFactory>{std::move(factory)};
-}
-
-} // namespace fsd
-#endif
-
 } // namespace pushmi

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -38,7 +38,7 @@ SCENARIO( "async", "[async]" ) {
         auto comparablething = op::just(2.0) |
           op::via([&](){return nt;}) |
           op::transform([exec = nt](auto v){
-            auto token = pushmi::detail::AsyncToken<
+            auto token = pushmi::detail::NewThreadAsyncToken<
                 std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
               exec};
             token.dataPtr_->v_ = std::forward<decltype(v)>(v);

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <set>
 
 using namespace std::literals;
 
@@ -21,19 +22,45 @@ using namespace std::literals;
 #include "pushmi/trampoline.h"
 #include "pushmi/new_thread.h"
 
+// Pause ensures that the tasks take long enough that the enqueue task
+// runs ahead and multiple threads are launched
+void pause() {
+  std::this_thread::sleep_for(100ms);
+}
+
 using namespace pushmi::aliases;
 
-SCENARIO( "async", "[async]" ) {
+struct __inline_submit {
 
+  template<class TP, class Out>
+  void operator()(TP at, Out out) const {
+    auto tr = ::pushmi::trampoline();
+    ::pushmi::submit(tr, std::move(at), std::move(out));
+  }
+};
+
+inline auto inline_executor() {
+  return ::pushmi::make_time_single_deferred(__inline_submit{});
+}
+
+SCENARIO( "async", "[async]" ) {
+  #if 1
   GIVEN( "A new_thread time_single_deferred" ) {
     auto nt = v::new_thread();
     using NT = decltype(nt);
 
-    auto workerTask = [](auto v) mutable {return v + 1;};
+    std::mutex threads_mutex;
 
     WHEN( "async task chain used with via" ) {
       {
         std::vector<std::string> values;
+        std::set<std::thread::id> threads;
+        auto workerTask = [&threads, &threads_mutex](auto v) mutable {
+          std::lock_guard<std::mutex> lck(threads_mutex);
+          threads.insert(std::this_thread::get_id());
+          pause();
+          return v + 1;
+        };
 
         auto comparablething = op::just(2.0) |
           op::via([&](){return nt;}) |
@@ -48,24 +75,99 @@ SCENARIO( "async", "[async]" ) {
             v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
             return v;
           }) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
           op::transform([](auto v){return v.dataPtr_->v_;}) |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
         THEN( "only the first item was pushed" ) {
-          REQUIRE(values == std::vector<std::string>{"3.000000"});
+          REQUIRE(values == std::vector<std::string>{"8.000000"});
+          // Should be inline on a single thread as transform is literal
+          REQUIRE(threads.size() == 1);
         }
       }
 
       {
         std::vector<std::string> values;
+        std::set<std::thread::id> threads;
+        auto workerTask = [&threads, &threads_mutex](auto v) mutable {
+          std::lock_guard<std::mutex> lck(threads_mutex);
+          threads.insert(std::this_thread::get_id());
+          std::this_thread::sleep_for(100ms);
+          pause();
+          return v + 1;
+        };
+
         auto realthing = op::just(2.0) |
           op::async_fork([&](){return nt;}) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
           op::async_transform(workerTask) |
           op::async_join() |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
         THEN( "only the first item was pushed" ) {
-          REQUIRE(values == std::vector<std::string>{"3.000000"});
+          REQUIRE(values == std::vector<std::string>{"8.000000"});
+          // Should be asynchronous on multiple threads
+          REQUIRE(threads.size() != 1);
+        }
+      }
+    }
+  }
+  #endif
+
+  GIVEN( "An inline time_single_deferred" ) {
+    auto nt = inline_executor();
+    using NT = decltype(nt);
+    std::mutex threads_mutex;
+
+    WHEN( "async task chain used with via" ) {
+      {
+        std::vector<std::string> values;
+        std::set<std::thread::id> threads;
+        auto workerTask = [&threads, &threads_mutex](auto v) mutable {
+          std::lock_guard<std::mutex> lck(threads_mutex);
+          threads.insert(std::this_thread::get_id());
+          pause();
+          return v + 1;
+        };
+
+        auto realthing = op::just(2.0) |
+          op::async_fork([&](){return nt;}) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_transform(workerTask) |
+          op::async_join() |
+          op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
+
+        THEN( "only the first item was pushed" ) {
+          REQUIRE(values == std::vector<std::string>{"8.000000"});
+          // Should have all been inline on a single thread
+          REQUIRE(threads.size() == 1);
         }
       }
     }

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -8,6 +8,7 @@
 using namespace std::literals;
 
 #include "pushmi/flow_single_deferred.h"
+#include "pushmi/o/async.h"
 #include "pushmi/o/empty.h"
 #include "pushmi/o/just.h"
 #include "pushmi/o/on.h"
@@ -22,193 +23,6 @@ using namespace std::literals;
 
 using namespace pushmi::aliases;
 
-template<class ValueType, class ExecutorType>
-struct AsyncToken {
-public:
-  struct Data {
-    Data(ValueType v) : v_(std::move(v)) {}
-    ValueType v_;
-    std::condition_variable cv_;
-    std::mutex cvm_;
-    bool flag_ = false;
-  };
-
-  AsyncToken(ExecutorType e, ValueType v) :
-    e_{std::move(e)}, dataPtr_{std::make_shared<Data>(std::move(v))} {}
-
-  ExecutorType e_;
-  std::shared_ptr<Data> dataPtr_;
-};
-
-
-namespace pushmi {
-namespace detail {
-  template<class Executor, class Out>
-  struct async_fork_fn_data : public Out {
-    Executor exec;
-
-    async_fork_fn_data(Out out, Executor exec) :
-      Out(std::move(out)), exec(std::move(exec)) {}
-  };
-
-  template<class Out, class Executor>
-  auto make_async_fork_fn_data(Out out, Executor ex) -> async_fork_fn_data<Executor, Out> {
-    return {std::move(out), std::move(ex)};
-  }
-
-  struct async_fork_fn {
-    PUSHMI_TEMPLATE(class ExecutorFactory)
-      (requires Invocable<ExecutorFactory&>)
-    auto operator()(ExecutorFactory ef) const {
-      return constrain(lazy::Sender<_1>, [ef = std::move(ef)](auto in) {
-        using In = decltype(in);
-        return ::pushmi::detail::deferred_from<In, single<>>(
-          std::move(in),
-          ::pushmi::detail::submit_transform_out<In>(
-            constrain(lazy::Receiver<_1>, [ef](auto out) {
-              using Out = decltype(out);
-              auto exec = ef();
-              return ::pushmi::detail::out_from_fn<In>()(
-                make_async_fork_fn_data(std::move(out), std::move(exec)),
-                // copy 'f' to allow multiple calls to submit
-                ::pushmi::on_value([](auto& data, auto&& v) {
-                  using V = decltype(v);
-                  auto exec = data.exec;
-                  ::pushmi::submit(
-                    exec,
-                    ::pushmi::now(exec),
-                    ::pushmi::make_single(
-                      [v = (V&&)v, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
-                        // Token hard coded for this executor type at the moment
-                        auto token = AsyncToken<
-                            std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
-                          exec, std::forward<decltype(v)>(v)};
-                        token.dataPtr_->flag_ = true;
-                        ::pushmi::set_value(out, std::move(token));
-                      }
-                    )
-                  );
-                }),
-                ::pushmi::on_error([](auto& data, auto e) noexcept {
-                  ::pushmi::submit(
-                    data.exec,
-                    ::pushmi::now(data.exec),
-                    ::pushmi::make_single(
-                      [e = std::move(e), out = std::move(static_cast<Out&>(data))](auto) mutable {
-                        ::pushmi::set_error(out, std::move(e));
-                      }
-                    )
-                  );
-                }),
-                ::pushmi::on_done([](auto& data){
-                  ::pushmi::submit(
-                    data.exec,
-                    ::pushmi::now(data.exec),
-                    ::pushmi::make_single(
-                      [out = std::move(static_cast<Out&>(data))](auto) mutable {
-                        ::pushmi::set_done(out);
-                      }
-                    )
-                  );
-                })
-              );
-            })
-          )
-        );
-      });
-    }
-  };
-
-} // namespace detail
-
-namespace operators {
-PUSHMI_INLINE_VAR constexpr detail::async_fork_fn async_fork{};
-} // namespace operators
-} // namespace pushmi
-
-
-namespace pushmi {
-namespace detail {
-  template<class Out>
-  struct async_join_fn_data : public Out {
-    async_join_fn_data(Out out) :
-      Out(std::move(out)) {}
-  };
-
-  template<class Out>
-  auto make_async_join_fn_data(Out out) -> async_join_fn_data<Out> {
-    return {std::move(out)};
-  }
-
-  struct async_join_fn {
-    auto operator()() const {
-      return constrain(lazy::Sender<_1>, [](auto in) {
-        using In = decltype(in);
-        return ::pushmi::detail::deferred_from<In, single<>>(
-          std::move(in),
-          ::pushmi::detail::submit_transform_out<In>(
-            constrain(lazy::Receiver<_1>, [](auto out) {
-              using Out = decltype(out);
-              return ::pushmi::detail::out_from_fn<In>()(
-                make_async_join_fn_data(std::move(out)),
-                // copy 'f' to allow multiple calls to submit
-                ::pushmi::on_value([](auto& data, auto&& asyncToken) {
-                  // Async version that does not - why not?
-                  using V = decltype(asyncToken);
-                  auto exec = asyncToken.e_;
-                  ::pushmi::submit(
-                    exec,
-                    ::pushmi::now(exec),
-                    ::pushmi::make_single(
-                      [asyncToken, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
-                        // Token hard coded for this executor type at the moment
-                        std::thread t([
-                           exec,
-                           asyncToken,
-                           out]() mutable {
-                          std::unique_lock<std::mutex> lk(asyncToken.dataPtr_->cvm_);
-                          if(!asyncToken.dataPtr_->flag_) {
-                            asyncToken.dataPtr_->cv_.wait(
-                              lk, [&](){return asyncToken.dataPtr_->flag_;});
-                          }
-                          ::pushmi::submit(
-                            exec,
-                            ::pushmi::now(exec),
-                            ::pushmi::make_single(
-                              [asyncToken, out, exec](auto) mutable {
-                                // Token hard coded for this executor type at the moment
-                                ::pushmi::set_value(out, std::move(asyncToken.dataPtr_->v_));
-                              }
-                            ));
-                        });
-                        t.detach();
-                      }
-                    )
-                  );
-                }),
-                ::pushmi::on_error([](auto& data, auto e) noexcept {
-                  auto out = std::move(static_cast<Out&>(data));
-                  ::pushmi::set_error(out, std::move(e));
-                }),
-                ::pushmi::on_done([](auto& data){
-                  auto out = std::move(static_cast<Out&>(data));
-                  ::pushmi::set_done(out);
-                })
-              );
-            })
-          )
-        );
-      });
-    }
-  };
-
-} // namespace detail
-
-namespace operators {
-PUSHMI_INLINE_VAR constexpr detail::async_join_fn async_join{};
-} // namespace operators
-} // namespace pushmi
-
 // This should specialise using customisation points
 // For now it just assumes that this executor deals with threads and creates a
 // new thread for each node.
@@ -216,15 +30,15 @@ PUSHMI_INLINE_VAR constexpr detail::async_join_fn async_join{};
 auto async_join() {
    return pushmi::make_single_deferred(
      [](auto out){
-       return v::on_value([out = std::move(out)](auto asyncToken){
+       return v::on_value([out = std::move(out)](auto pushmi::detail::AsyncToken){
          std::thread t([
-            asyncToken = std::move(asyncToken),
+            pushmi::detail::AsyncToken = std::move(pushmi::detail::AsyncToken),
             out = std::move(out)](){
-           std::unique_lock<std::mutex> lk(asyncToken.data_->cvm_);
-           asyncToken.data_->cv_.wait(lk);
-           op::via([](){return asyncToken.e_;}) |
-              v::on_value([asyncToken, out = std::move(out)](auto&){
-                ::pushmi::set_value(out, std::move(asyncToken.data_->v_));
+           std::unique_lock<std::mutex> lk(pushmi::detail::AsyncToken.data_->cvm_);
+           pushmi::detail::AsyncToken.data_->cv_.wait(lk);
+           op::via([](){return pushmi::detail::AsyncToken.e_;}) |
+              v::on_value([pushmi::detail::AsyncToken, out = std::move(out)](auto&){
+                ::pushmi::set_value(out, std::move(pushmi::detail::AsyncToken.data_->v_));
               });
          });
          t.detach();
@@ -245,7 +59,7 @@ SCENARIO( "async", "[async]" ) {
         auto comparablething = op::just(2.0) |
           op::via([&](){return nt;}) |
           op::transform([exec = nt](auto v){
-            return AsyncToken<
+            return pushmi::detail::AsyncToken<
                 std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
               exec, std::forward<decltype(v)>(v)};
           }) |

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -82,6 +82,7 @@ namespace detail {
                         auto token = AsyncToken<
                             std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
                           exec, std::forward<decltype(v)>(v)};
+                        token.dataPtr_->cv_.notify_all();
                         ::pushmi::set_value(out, std::move(token));
                       }
                     )
@@ -125,6 +126,109 @@ PUSHMI_INLINE_VAR constexpr detail::async_fork_fn async_fork{};
 } // namespace pushmi
 
 
+namespace pushmi {
+namespace detail {
+  template<class Out>
+  struct async_join_fn_data : public Out {
+    async_join_fn_data(Out out) :
+      Out(std::move(out)) {}
+  };
+
+  template<class Out>
+  auto make_async_join_fn_data(Out out) -> async_join_fn_data<Out> {
+    return {std::move(out)};
+  }
+
+  struct async_join_fn {
+    auto operator()() const {
+      return constrain(lazy::Sender<_1>, [](auto in) {
+        using In = decltype(in);
+        return ::pushmi::detail::deferred_from<In, single<>>(
+          std::move(in),
+          ::pushmi::detail::submit_transform_out<In>(
+            constrain(lazy::Receiver<_1>, [](auto out) {
+              using Out = decltype(out);
+              return ::pushmi::detail::out_from_fn<In>()(
+                make_async_join_fn_data(std::move(out)),
+                // copy 'f' to allow multiple calls to submit
+                ::pushmi::on_value([](auto& data, auto&& asyncToken) {
+                  // Async version that does not - why not?
+                  using V = decltype(asyncToken);
+                  auto exec = asyncToken.e_;
+                  ::pushmi::submit(
+                    exec,
+                    ::pushmi::now(exec),
+                    ::pushmi::make_single(
+                      [asyncToken, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
+                        // Token hard coded for this executor type at the moment
+                        std::thread t([
+                           exec,
+                           asyncToken,
+                           out]() mutable {
+                          std::unique_lock<std::mutex> lk(asyncToken.dataPtr_->cvm_);
+                          // TODO: Currently this never wakes up. Fix to work properly.
+                          //asyncToken.dataPtr_->cv_.wait(lk);
+                          ::pushmi::submit(
+                            exec,
+                            ::pushmi::now(exec),
+                            ::pushmi::make_single(
+                              [asyncToken, out, exec](auto) mutable {
+                                // Token hard coded for this executor type at the moment
+                                ::pushmi::set_value(out, std::move(asyncToken.dataPtr_->v_));
+                              }
+                            ));
+                        });
+                        t.detach();
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_error([](auto& data, auto e) noexcept {
+                  auto out = std::move(static_cast<Out&>(data));
+                  ::pushmi::set_error(out, std::move(e));
+                }),
+                ::pushmi::on_done([](auto& data){
+                  auto out = std::move(static_cast<Out&>(data));
+                  ::pushmi::set_done(out);
+                })
+              );
+            })
+          )
+        );
+      });
+    }
+  };
+
+} // namespace detail
+
+namespace operators {
+PUSHMI_INLINE_VAR constexpr detail::async_join_fn async_join{};
+} // namespace operators
+} // namespace pushmi
+
+// This should specialise using customisation points
+// For now it just assumes that this executor deals with threads and creates a
+// new thread for each node.
+/*
+auto async_join() {
+   return pushmi::make_single_deferred(
+     [](auto out){
+       return v::on_value([out = std::move(out)](auto asyncToken){
+         std::thread t([
+            asyncToken = std::move(asyncToken),
+            out = std::move(out)](){
+           std::unique_lock<std::mutex> lk(asyncToken.data_->cvm_);
+           asyncToken.data_->cv_.wait(lk);
+           op::via([](){return asyncToken.e_;}) |
+              v::on_value([asyncToken, out = std::move(out)](auto&){
+                ::pushmi::set_value(out, std::move(asyncToken.data_->v_));
+              });
+         });
+         t.detach();
+       });
+     });
+}*/
+
 SCENARIO( "async", "[async]" ) {
 
   GIVEN( "A new_thread time_single_deferred" ) {
@@ -142,6 +246,7 @@ SCENARIO( "async", "[async]" ) {
                 std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
               exec, std::forward<decltype(v)>(v)};
           }) |
+          op::transform([](auto v){auto ptr = v.dataPtr_; return v;}) |
           op::transform([](auto v){return v.dataPtr_->v_;}) |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
@@ -154,7 +259,8 @@ SCENARIO( "async", "[async]" ) {
         std::vector<std::string> values;
         auto realthing = op::just(2.0) |
           op::async_fork([&](){return nt;}) |
-          op::transform([](auto v){return v.dataPtr_->v_;}) |
+          op::transform([](auto v){auto ptr = v.dataPtr_; return v;}) |
+          op::async_join() |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
         THEN( "only the first item was pushed" ) {

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -1,0 +1,174 @@
+#include "catch.hpp"
+
+#include <type_traits>
+
+#include <chrono>
+#include <condition_variable>
+
+using namespace std::literals;
+
+#include "pushmi/flow_single_deferred.h"
+#include "pushmi/o/empty.h"
+#include "pushmi/o/just.h"
+#include "pushmi/o/on.h"
+#include "pushmi/o/transform.h"
+#include "pushmi/o/tap.h"
+#include "pushmi/o/via.h"
+#include "pushmi/o/submit.h"
+#include "pushmi/o/extension_operators.h"
+
+#include "pushmi/trampoline.h"
+#include "pushmi/new_thread.h"
+
+using namespace pushmi::aliases;
+
+template<class ValueType, class ExecutorType>
+struct AsyncToken {
+public:
+  struct Data {
+    Data(ValueType v) : v_(std::move(v)) {}
+    ValueType v_;
+    std::condition_variable cv_;
+    std::mutex cvm_;
+  };
+
+  AsyncToken(ExecutorType e, ValueType v) :
+    e_{std::move(e)}, dataPtr_{std::make_shared<Data>(std::move(v))} {}
+
+  ExecutorType e_;
+  std::shared_ptr<Data> dataPtr_;
+};
+
+
+namespace pushmi {
+namespace detail {
+  template<class Executor, class Out>
+  struct async_fork_fn_data : public Out {
+    Executor exec;
+
+    async_fork_fn_data(Out out, Executor exec) :
+      Out(std::move(out)), exec(std::move(exec)) {}
+  };
+
+  template<class Out, class Executor>
+  auto make_async_fork_fn_data(Out out, Executor ex) -> async_fork_fn_data<Executor, Out> {
+    return {std::move(out), std::move(ex)};
+  }
+
+  struct async_fork_fn {
+    PUSHMI_TEMPLATE(class ExecutorFactory)
+      (requires Invocable<ExecutorFactory&>)
+    auto operator()(ExecutorFactory ef) const {
+      return constrain(lazy::Sender<_1>, [ef = std::move(ef)](auto in) {
+        using In = decltype(in);
+        return ::pushmi::detail::deferred_from<In, single<>>(
+          std::move(in),
+          ::pushmi::detail::submit_transform_out<In>(
+            constrain(lazy::Receiver<_1>, [ef](auto out) {
+              using Out = decltype(out);
+              auto exec = ef();
+              return ::pushmi::detail::out_from_fn<In>()(
+                make_async_fork_fn_data(std::move(out), std::move(exec)),
+                // copy 'f' to allow multiple calls to submit
+                ::pushmi::on_value([](auto& data, auto&& v) {
+                  using V = decltype(v);
+                  auto exec = data.exec;
+                  ::pushmi::submit(
+                    exec,
+                    ::pushmi::now(exec),
+                    ::pushmi::make_single(
+                      [v = (V&&)v, out = std::move(static_cast<Out&>(data)), exec](auto) mutable {
+                        // Token hard coded for this executor type at the moment
+                        auto token = AsyncToken<
+                            std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
+                          exec, std::forward<decltype(v)>(v)};
+                        ::pushmi::set_value(out, std::move(token));
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_error([](auto& data, auto e) noexcept {
+                  ::pushmi::submit(
+                    data.exec,
+                    ::pushmi::now(data.exec),
+                    ::pushmi::make_single(
+                      [e = std::move(e), out = std::move(static_cast<Out&>(data))](auto) mutable {
+                        ::pushmi::set_error(out, std::move(e));
+                      }
+                    )
+                  );
+                }),
+                ::pushmi::on_done([](auto& data){
+                  ::pushmi::submit(
+                    data.exec,
+                    ::pushmi::now(data.exec),
+                    ::pushmi::make_single(
+                      [out = std::move(static_cast<Out&>(data))](auto) mutable {
+                        ::pushmi::set_done(out);
+                      }
+                    )
+                  );
+                })
+              );
+            })
+          )
+        );
+      });
+    }
+  };
+
+} // namespace detail
+
+namespace operators {
+PUSHMI_INLINE_VAR constexpr detail::async_fork_fn async_fork{};
+} // namespace operators
+} // namespace pushmi
+
+
+SCENARIO( "async", "[async]" ) {
+
+  GIVEN( "A new_thread time_single_deferred" ) {
+    auto nt = v::new_thread();
+    using NT = decltype(nt);
+
+    WHEN( "async task chain used with via" ) {
+      {
+        std::vector<std::string> values;
+
+        auto comparablething = op::just(2.0) |
+          op::via([&](){return nt;}) |
+          op::transform([exec = nt](auto v){
+            return AsyncToken<
+                std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
+              exec, std::forward<decltype(v)>(v)};
+          }) |
+          op::transform([](auto v){return v.dataPtr_->v_;}) |
+          op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
+
+        THEN( "only the first item was pushed" ) {
+          REQUIRE(values == std::vector<std::string>{"2.000000"});
+        }
+      }
+
+      {
+        std::vector<std::string> values;
+        auto realthing = op::just(2.0) |
+          op::async_fork([&](){return nt;}) |
+          op::transform([](auto v){return v.dataPtr_->v_;}) |
+          op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
+
+        THEN( "only the first item was pushed" ) {
+          REQUIRE(values == std::vector<std::string>{"2.000000"});
+        }
+      }
+    }
+  }
+}
+
+/*
+v::bulk_on_value(
+  [](size_t idx, auto& shared){shared += idx;},
+  []() -> size_t { return 10; },
+  [](size_t shape){ return 0; },
+  [](auto& shared){return shared;})
+*/

--- a/test/AsyncTest.cpp
+++ b/test/AsyncTest.cpp
@@ -23,34 +23,13 @@ using namespace std::literals;
 
 using namespace pushmi::aliases;
 
-// This should specialise using customisation points
-// For now it just assumes that this executor deals with threads and creates a
-// new thread for each node.
-/*
-auto async_join() {
-   return pushmi::make_single_deferred(
-     [](auto out){
-       return v::on_value([out = std::move(out)](auto pushmi::detail::AsyncToken){
-         std::thread t([
-            pushmi::detail::AsyncToken = std::move(pushmi::detail::AsyncToken),
-            out = std::move(out)](){
-           std::unique_lock<std::mutex> lk(pushmi::detail::AsyncToken.data_->cvm_);
-           pushmi::detail::AsyncToken.data_->cv_.wait(lk);
-           op::via([](){return pushmi::detail::AsyncToken.e_;}) |
-              v::on_value([pushmi::detail::AsyncToken, out = std::move(out)](auto&){
-                ::pushmi::set_value(out, std::move(pushmi::detail::AsyncToken.data_->v_));
-              });
-         });
-         t.detach();
-       });
-     });
-}*/
-
 SCENARIO( "async", "[async]" ) {
 
   GIVEN( "A new_thread time_single_deferred" ) {
     auto nt = v::new_thread();
     using NT = decltype(nt);
+
+    auto workerTask = [](auto v) mutable {return v + 1;};
 
     WHEN( "async task chain used with via" ) {
       {
@@ -59,16 +38,21 @@ SCENARIO( "async", "[async]" ) {
         auto comparablething = op::just(2.0) |
           op::via([&](){return nt;}) |
           op::transform([exec = nt](auto v){
-            return pushmi::detail::AsyncToken<
+            auto token = pushmi::detail::AsyncToken<
                 std::decay_t<decltype(v)>, std::decay_t<decltype(exec)>>{
-              exec, std::forward<decltype(v)>(v)};
+              exec};
+            token.dataPtr_->v_ = std::forward<decltype(v)>(v);
+            return token;
           }) |
-          op::transform([](auto v){auto ptr = v.dataPtr_; return v;}) |
+          op::transform([workerTask](auto v) mutable {
+            v.dataPtr_->v_ = workerTask(v.dataPtr_->v_);
+            return v;
+          }) |
           op::transform([](auto v){return v.dataPtr_->v_;}) |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
         THEN( "only the first item was pushed" ) {
-          REQUIRE(values == std::vector<std::string>{"2.000000"});
+          REQUIRE(values == std::vector<std::string>{"3.000000"});
         }
       }
 
@@ -76,12 +60,12 @@ SCENARIO( "async", "[async]" ) {
         std::vector<std::string> values;
         auto realthing = op::just(2.0) |
           op::async_fork([&](){return nt;}) |
-          op::transform([](auto v){auto ptr = v.dataPtr_; return v;}) |
+          op::async_transform(workerTask) |
           op::async_join() |
           op::blocking_submit(v::on_value([&](auto v) { values.push_back(std::to_string(v)); }));
 
         THEN( "only the first item was pushed" ) {
-          REQUIRE(values == std::vector<std::string>{"2.000000"});
+          REQUIRE(values == std::vector<std::string>{"3.000000"});
         }
       }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_executable(PushmiTest
   catch.cpp
+  AsyncTest.cpp
   CompileTest.cpp
   NewThreadTest.cpp
   TrampolineTest.cpp


### PR DESCRIPTION
This change demonstrates the most general form of what we should build bulk on top of.

A bulk task is just some sort of parallel operation with a single input and output. Bulk as envisaged, however, also implies some sort of asynchronous queuing. We can build asynchronous queuing directly into pushmi with no extra fundamental concepts, instead a set of customisation points. 

This change shows how that works with a very simple implementation - an async transform that, for each transform operation it hits enqueues a new thread. Each transform waits on the previous one using a condition variable and heap-allocated value.

The main executor control flow simply passes a synchronisation token along, firing off the transform to one side and using a join customisation point to rejoin and turn this back into a more traditional value flow at the end.

We customise here on an inline_executor, which is not async at all, and on the new_thread executor which customises the thread creation behaviour. A GPU executor would fire off GPU enqueue primitives, only adding a bulk operation in addition to the scalar transform we see here.