### PR TITLE
Remove stopping signal

### DIFF
--- a/buildSingleHeader.cmake
+++ b/buildSingleHeader.cmake
@@ -27,6 +27,7 @@ set(header_files
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/detail/functional.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/detail/opt.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/forwards.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/entangle.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/extension_points.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/properties.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/pushmi/concepts.h"

--- a/include/pushmi.h
+++ b/include/pushmi.h
@@ -1301,6 +1301,216 @@ namespace aliases {
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+//#include "forwards.h"
+
+namespace pushmi {
+
+#if 0
+
+template <class T, class Dual>
+struct entangled {
+  T t;
+  entangled<Dual, T>* dual;
+
+  ~entangled() {
+    if (!!dual) {
+      dual->dual = nullptr;
+    }
+  }
+  explicit entangled(T t) : t(std::move(t)), dual(nullptr) {}
+  entangled(entangled&& o) : t(std::move(o.t)), dual(o.dual) {
+    o.dual = nullptr;
+    if (!!dual) {
+      dual->dual = this;
+    }
+  }
+
+  entangled() = delete;
+  entangled(const entangled&) = delete;
+  entangled& operator=(const entangled&) = delete;
+  entangled& operator=(entangled&&) = delete;
+
+  Dual* lockPointerToDual() {
+    if (!!dual) {
+      return std::addressof(dual->t);
+    }
+    return nullptr;
+  }
+
+  void unlockPointerToDual() {
+  }
+};
+
+#else
+
+// This class can be used to keep a pair of values with pointers to each other
+// in sync, even when both objects are allowed to move. Ordinarily you'd do this
+// with a heap-allocated, refcounted, control block (or do something else using
+// external storage, like a lock table chosen by the current addresses of both
+// objects).
+// Another thing you could do is have locks, and a backoff strategy for dealing
+// with deadlock: lock locally, trylock your dual, if the trylock fails,
+// unlock yourself, wait a little while (giving a thread touching the dual a
+// chance to acquire the local lock), and repeat. That's kind of ugly.
+// This algorithm (which, to be clear, is untested and I haven't really even
+// thought through carefully) provides the same guarantees, but without using
+// external storage or backoff-based deadlock recovery.
+
+template <class T, class Dual>
+struct entangled {
+  // must be constructed first so that the other.lockBoth() in the move
+  // constructor is run before moving other.t and other.dual
+  std::atomic<int> stateMachine;
+
+  T t;
+  // In a couple places, we can save on some atomic ops by making this atomic,
+  // and adding a "dual == null" fast-path without locking.
+  entangled<Dual, T>* dual;
+
+  const static int kUnlocked = 0;
+  const static int kLocked = 1;
+  const static int kLockedAndLossAcknowledged = 2;
+
+  // Note: *not* thread-safe; it's a bug for two threads to concurrently call
+  // lockBoth() on the same entangled (just as it's a bug for two threads to
+  // concurrently move from the same object).
+  // However, calling lockBoth() on two entangled objects at once is
+  // thread-safe.
+  // Note also that this may wait indefinitely; it's not the usual non-blocking
+  // tryLock().
+  bool tryLockBoth() {
+    // Try to acquire the local lock. We have to start locally, since local
+    // addresses are the only ones we know are safe at first. The rule is, you
+    // have to hold *both* locks to write any of either entangled object's
+    // metadata, but need only one to read it.
+    int expected = kUnlocked;
+    if (!stateMachine.compare_exchange_weak(expected, kLocked)) {
+      return false;
+    }
+    // Having *either* object local-locked protects the data in both objects.
+    // Once we hold our lock, no control data can change, in either object.
+    if (dual == nullptr) {
+      return true;
+    }
+    expected = kUnlocked;
+    if (dual->stateMachine.compare_exchange_strong(expected, kLocked)) {
+      return true;
+    }
+    // We got here, and so hit the race; we're deadlocked if we stick to
+    // locking. Revert to address-ordering. Note that address-ordering would
+    // not be safe on its own, because of the lifetime issues involved; the
+    // addresses here are only stable *because* we know both sides are locked,
+    // and because of the invariant that you must hold both locks to modify
+    // either piece of data.
+    if ((uintptr_t)this < (uintptr_t)dual) {
+      // I get to win the race. I'll acquire the locks, but have to make sure
+      // my memory stays valid until the other thread acknowledges its loss.
+      while (stateMachine.load() != kLockedAndLossAcknowledged) {
+        // Spin.
+      }
+      stateMachine.store(kLocked);
+      return true;
+    } else {
+      // I lose the race, but have to coordinate with the winning thread, so
+      // that it knows that I'm not about to try to touch it's data
+      dual->stateMachine.store(kLockedAndLossAcknowledged);
+      return false;
+    }
+  }
+
+  void lockBoth() {
+    while (!tryLockBoth()) {
+      // Spin. But, note that all the unbounded spinning in tryLockBoth can be
+      // straightforwardly futex-ified. There's a potentialy starvation issue
+      // here, but note that it can be dealt with by adding a "priority" bit to
+      // the state machine (i.e. if my priority bit is set, the thread for whom
+      // I'm the local member of the pair gets to win the race, rather than
+      // using address-ordering).
+    }
+  }
+
+  void unlockBoth() {
+    // Note that unlocking locally and then remotely is the right order. There
+    // are no concurrent accesses to this object (as an API constraint -- lock
+    // and unlock are not thread safe!), and no other thread will touch the
+    // other object so long as its locked. Going in the other order could let
+    // another thread incorrectly think we're going down the deadlock-avoidance
+    // path in tryLock().
+    stateMachine.store(kUnlocked);
+    if (dual != nullptr) {
+      dual->stateMachine.store(kUnlocked);
+    }
+  }
+
+  entangled() = delete;
+  entangled(const entangled&) = delete;
+  entangled& operator=(const entangled&) = delete;
+  entangled& operator=(entangled&&) = delete;
+
+  explicit entangled(T t)
+      : t(std::move(t)), dual(nullptr), stateMachine(kUnlocked) {}
+  entangled(entangled&& other)
+      : stateMachine((other.lockBoth(), kLocked)),
+        t(std::move(other.t)),
+        dual(std::move(other.dual)) {
+    // Note that, above, we initialized stateMachine to the locked state; the
+    // address of this object hasn't escaped yet, and won't (until we unlock
+    // the dual), so it doesn't *really* matter, but it's conceptually helpful
+    // to maintain that invariant.
+
+    // Update our dual's data.
+    if (dual != nullptr) {
+      dual->dual = this;
+    }
+
+    // Update other's data.
+    other.dual = nullptr;
+    // unlock other so that its destructor can complete
+    other.stateMachine.store(kUnlocked);
+
+    // We locked on other, but will unlock on *this. The locking protocol
+    // ensured that no accesses to other will occur after lock() returns, and
+    // since then we updated dual's dual to be us.
+    unlockBoth();
+  }
+
+  ~entangled() {
+    lockBoth();
+    if (dual != nullptr) {
+      dual->dual = nullptr;
+    }
+    unlockBoth();
+  }
+
+  // Must unlock later even if dual is nullptr. This is fixable.
+  Dual* lockPointerToDual() {
+    lockBoth();
+    return !!dual ? std::addressof(dual->t) : nullptr;
+  }
+
+  void unlockPointerToDual() {
+    unlockBoth();
+  }
+};
+#endif
+
+template <class First, class Second>
+auto entangle(First f, Second s)
+    -> std::pair<entangled<First, Second>, entangled<Second, First>> {
+  entangled<First, Second> ef(std::move(f));
+  entangled<Second, First> es(std::move(s));
+  ef.dual = std::addressof(es);
+  es.dual = std::addressof(ef);
+  return {std::move(ef), std::move(es)};
+}
+
+} // namespace pushmi
+//#pragma once
+// Copyright (c) 2018-present, Facebook, Inc.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 //#include <future>
 //#include <functional>
 

--- a/include/pushmi/boosters.h
+++ b/include/pushmi/boosters.h
@@ -56,10 +56,6 @@ struct ignoreDF {
   void operator()() {}
 };
 
-struct ignoreStpF {
-  void operator()() {}
-};
-
 struct ignoreStrtF {
   template <class Up>
   void operator()(Up&&) {}
@@ -100,14 +96,6 @@ struct passDDF {
     (requires Receiver<Data>)
   void operator()(Data& out) const {
     ::pushmi::set_done(out);
-  }
-};
-
-struct passDStpF {
-  PUSHMI_TEMPLATE(class Data)
-    (requires Receiver<Data>)
-  void operator()(Data& out) const {
-    ::pushmi::set_stopping(out);
   }
 };
 
@@ -241,18 +229,6 @@ struct on_done_fn : Fn {
 template <class Fn>
 auto on_done(Fn fn) -> on_done_fn<Fn> {
   return on_done_fn<Fn>{std::move(fn)};
-}
-
-template <class Fn>
-struct on_stopping_fn : Fn {
-  constexpr on_stopping_fn() = default;
-  constexpr explicit on_stopping_fn(Fn fn) : Fn(std::move(fn)) {}
-  using Fn::operator();
-};
-
-template <class Fn>
-auto on_stopping(Fn fn) -> on_stopping_fn<Fn> {
-  return on_stopping_fn<Fn>{std::move(fn)};
 }
 
 template <class... Fns>

--- a/include/pushmi/concepts.h
+++ b/include/pushmi/concepts.h
@@ -256,9 +256,6 @@ PUSHMI_CONCEPT_DEF(
 PUSHMI_CONCEPT_DEF(
   template (class S, class... PropertyN)
   (concept FlowReceiver)(S, PropertyN...),
-    requires(S& s) (
-      ::pushmi::set_stopping(s)
-    ) &&
     Receiver<S> &&
     property_query_v<S, PropertyN...> &&
     Flow<S>

--- a/include/pushmi/extension_points.h
+++ b/include/pushmi/extension_points.h
@@ -27,11 +27,6 @@ void set_value(S& s, V&& v) noexcept(noexcept(s.value((V&&) v))) {
   s.value((V&&) v);
 }
 
-PUSHMI_TEMPLATE (class S)
-  (requires requires (std::declval<S&>().stopping()))
-void set_stopping(S& s) noexcept(noexcept(s.stopping())) {
-  s.stopping();
-}
 PUSHMI_TEMPLATE (class S, class Up)
   (requires requires (std::declval<S&>().starting(std::declval<Up>())))
 void set_starting(S& s, Up up) noexcept(noexcept(s.starting(std::move(up)))) {
@@ -99,12 +94,6 @@ PUSHMI_TEMPLATE (class S, class V)
 void set_value(std::reference_wrapper<S> s, V&& v) noexcept(
   noexcept(set_value(s.get(), (V&&) v))) {
   set_value(s.get(), (V&&) v);
-}
-PUSHMI_TEMPLATE (class S)
-  (requires requires ( set_stopping(std::declval<S&>()) ))
-void set_stopping(std::reference_wrapper<S> s) noexcept(
-  noexcept(set_stopping(s.get()))) {
-  set_stopping(s.get());
 }
 PUSHMI_TEMPLATE (class S, class Up)
   (requires requires ( set_starting(std::declval<S&>(), std::declval<Up>()) ))
@@ -176,15 +165,6 @@ struct set_value_fn {
   }
 };
 
-struct set_stopping_fn {
-  PUSHMI_TEMPLATE (class S)
-    (requires requires (
-      set_stopping(std::declval<S&>())
-    ))
-  void operator()(S&& s) const noexcept(noexcept(set_stopping(s))) {
-    set_stopping(s);
-  }
-};
 struct set_starting_fn {
   PUSHMI_TEMPLATE (class S, class Up)
     (requires requires (
@@ -239,7 +219,6 @@ struct get_now_fn {
 PUSHMI_INLINE_VAR constexpr __adl::set_done_fn set_done{};
 PUSHMI_INLINE_VAR constexpr __adl::set_error_fn set_error{};
 PUSHMI_INLINE_VAR constexpr __adl::set_value_fn set_value{};
-PUSHMI_INLINE_VAR constexpr __adl::set_stopping_fn set_stopping{};
 PUSHMI_INLINE_VAR constexpr __adl::set_starting_fn set_starting{};
 PUSHMI_INLINE_VAR constexpr __adl::do_submit_fn submit{};
 PUSHMI_INLINE_VAR constexpr __adl::get_now_fn now{};

--- a/include/pushmi/o/extension_operators.h
+++ b/include/pushmi/o/extension_operators.h
@@ -214,16 +214,6 @@ struct set_done_fn {
   }
 };
 
-struct set_stopping_fn {
-  auto operator()() const {
-    return constrain(lazy::Receiver<_1>,
-      [](auto out) {
-        ::pushmi::set_stopping(out);
-      }
-    );
-  }
-};
-
 struct set_starting_fn {
   PUSHMI_TEMPLATE(class Up)
     (requires Receiver<Up>)
@@ -274,7 +264,6 @@ namespace extension_operators {
 PUSHMI_INLINE_VAR constexpr detail::set_done_fn set_done{};
 PUSHMI_INLINE_VAR constexpr detail::set_error_fn set_error{};
 PUSHMI_INLINE_VAR constexpr detail::set_value_fn set_value{};
-PUSHMI_INLINE_VAR constexpr detail::set_stopping_fn set_stopping{};
 PUSHMI_INLINE_VAR constexpr detail::set_starting_fn set_starting{};
 PUSHMI_INLINE_VAR constexpr detail::do_submit_fn submit{};
 PUSHMI_INLINE_VAR constexpr detail::now_fn now{};

--- a/include/pushmi/o/on.h
+++ b/include/pushmi/o/on.h
@@ -147,15 +147,6 @@ class fsdon {
         out_.error(std::move(e));
       }
 
-      void stopping() {
-        if (done_) {
-          return;
-        }
-        done_ = true;
-        *stopped_ = true;
-        out_.stopping();
-      }
-
       template <class Producer>
       void starting(RefWrapper<Producer> up) {
         upProxy_ =

--- a/include/pushmi/o/via.h
+++ b/include/pushmi/o/via.h
@@ -183,24 +183,6 @@ class fsdvia {
         });
       }
 
-      void stopping() {
-        if (done_) {
-          return;
-        }
-        if (!upProxy_) {
-          std::abort();
-        }
-        done_ = true;
-        if (!shared_->stopped_.exchange(true)) {
-          exec_ |
-              // must keep out and upProxy alive until out is notified that it
-              // is unsafe
-              execute([shared = shared_](auto) mutable {
-                shared->out_.stopping();
-              });
-        }
-      }
-
       template <class Producer>
       void starting(RefWrapper<Producer> up) {
         if (!!upProxy_) {

--- a/test/CompileTest.cpp
+++ b/test/CompileTest.cpp
@@ -257,13 +257,6 @@ void flow_single_test() {
         pushmi::ignoreVF{},
         pushmi::abortEF{},
         pushmi::ignoreDF{},
-        pushmi::ignoreStpF{});
-  auto out9 =
-      pushmi::MAKE(flow_single)(
-        pushmi::ignoreVF{},
-        pushmi::abortEF{},
-        pushmi::ignoreDF{},
-        pushmi::ignoreStpF{},
         pushmi::ignoreStrtF{});
 
   using Out0 = decltype(out0);
@@ -297,11 +290,6 @@ void flow_single_test() {
     pushmi::passDVF{},
     pushmi::passDEF{},
     pushmi::passDDF{});
-  auto proxy9 = pushmi::MAKE(flow_single)(out0,
-    pushmi::passDVF{},
-    pushmi::passDEF{},
-    pushmi::passDDF{},
-    pushmi::passDStpF{});
 
   auto any2 = pushmi::any_flow_single<int>(out0);
   auto any3 = pushmi::any_flow_single<int>(proxy0);

--- a/test/FlowTest.cpp
+++ b/test/FlowTest.cpp
@@ -46,11 +46,11 @@ SCENARIO("flow single immediate cancellation", "[flow][deferred]") {
       auto up = mi::MAKE(none)(
           Data{std::move(tokens.second)},
           [&](auto& data, auto e) noexcept {
-            signals += 1000000;
+            signals += 100000;
             data.stopper.t(data.stopper);
           },
           [&](auto& data) {
-            signals += 100000;
+            signals += 10000;
             data.stopper.t(data.stopper);
           });
 
@@ -64,9 +64,6 @@ SCENARIO("flow single immediate cancellation", "[flow][deferred]") {
         // cancellation is not an error
         ::mi::set_done(out);
       }
-      // I want to get rid of this signal it makes usage harder and
-      // messes up r-value qualifing done, error and value.
-      ::mi::set_stopping(out);
     });
 
     WHEN("submit is applied and cancels the producer") {
@@ -75,7 +72,6 @@ SCENARIO("flow single immediate cancellation", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // immediately stop producer
               mi::on_starting([&](auto up) {
                 signals += 10;
@@ -83,8 +79,8 @@ SCENARIO("flow single immediate cancellation", "[flow][deferred]") {
               }));
 
       THEN(
-          "the starting, up.done, out.done and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 110011);
+          "the starting, up.done and out.done signals are each recorded once") {
+        REQUIRE(signals == 10011);
       }
     }
 
@@ -94,13 +90,12 @@ SCENARIO("flow single immediate cancellation", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // do not stop producer before it is scheduled to run
               mi::on_starting([&](auto up) { signals += 10; }));
 
       THEN(
-          "the starting, out.value and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 10110);
+          "the starting and out.value signals are each recorded once") {
+        REQUIRE(signals == 110);
       }
     }
   }
@@ -132,11 +127,11 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
       auto up = mi::MAKE(none)(
           Data{std::move(tokens.second)},
           [&](auto& data, auto e) noexcept {
-            signals += 1000000;
+            signals += 100000;
             data.stopper.t(data.stopper);
           },
           [&](auto& data) {
-            signals += 100000;
+            signals += 10000;
             data.stopper.t(data.stopper);
           });
 
@@ -160,9 +155,6 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
                         // cancellation is not an error
                         ::mi::set_done(out);
                       }
-                      // I want to get rid of this signal it makes usage harder
-                      // and messes up r-value qualifing done, error and value.
-                      ::mi::set_stopping(out);
                     });
           });
     });
@@ -173,7 +165,6 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // stop producer before it is scheduled to run
               mi::on_starting([&](auto up) {
                 signals += 10;
@@ -183,8 +174,8 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
               }));
 
       THEN(
-          "the starting, up.done, out.done and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 110011);
+          "the starting, up.done and out.done signals are each recorded once") {
+        REQUIRE(signals == 10011);
       }
     }
 
@@ -194,7 +185,6 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // do not stop producer before it is scheduled to run
               mi::on_starting([&](auto up) {
                 signals += 10;
@@ -205,8 +195,8 @@ SCENARIO("flow single cancellation trampoline", "[flow][deferred]") {
               }));
 
       THEN(
-          "the starting, up.done, out.value and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 110110);
+          "the starting, up.done and out.value signals are each recorded once") {
+        REQUIRE(signals == 10110);
       }
     }
   }
@@ -248,11 +238,11 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
       auto up = mi::MAKE(none)(
           Data{std::move(tokens.second)},
           [&](auto& data, auto e) noexcept {
-            signals += 1000000;
+            signals += 100000;
             data.stopper.t(data.stopper);
           },
           [&](auto& data) {
-            signals += 100000;
+            signals += 10000;
             data.stopper.t(data.stopper);
           });
 
@@ -278,9 +268,6 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
                         // cancellation is not an error
                         ::mi::set_done(out);
                       }
-                      // I want to get rid of this signal it makes usage harder
-                      // and messes up r-value qualifing done, error and value.
-                      ::mi::set_stopping(out);
                     });
           });
     });
@@ -291,7 +278,6 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // stop producer before it is scheduled to run
               mi::on_starting([&](auto up) {
                 signals += 10;
@@ -303,8 +289,8 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
               }));
 
       THEN(
-          "the starting, up.done, out.done and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 110011);
+          "the starting, up.done and out.done signals are each recorded once") {
+        REQUIRE(signals == 10011);
       }
     }
 
@@ -314,7 +300,6 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
               mi::on_value([&](int) { signals += 100; }),
               mi::on_error([&](auto) noexcept { signals += 1000; }),
               mi::on_done([&]() { signals += 1; }),
-              mi::on_stopping([&]() { signals += 10000; }),
               // do not stop producer before it is scheduled to run
               mi::on_starting([&](auto up) {
                 signals += 10;
@@ -328,16 +313,16 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
       std::this_thread::sleep_for(100ms);
 
       THEN(
-          "the starting, up.done, out.value and out.stopping signals are each recorded once") {
-        REQUIRE(signals == 110110);
+          "the starting, up.done and out.value signals are each recorded once") {
+        REQUIRE(signals == 10110);
       }
     }
 
     WHEN("submit is applied and cancels the producer at the same time") {
       // count known results
       int total = 0;
-      int cancellostrace = 0; // 110110
-      int cancelled = 0; // 110011
+      int cancellostrace = 0; // 10110
+      int cancelled = 0; // 10011
 
       for (;;) {
         signals = 0;
@@ -348,7 +333,6 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
                 mi::on_value([&](int) { signals += 100; }),
                 mi::on_error([&](auto) noexcept { signals += 1000; }),
                 mi::on_done([&]() { signals += 1; }),
-                mi::on_stopping([&]() { signals += 10000; }),
                 // stop producer at the same time that it is scheduled to run
                 mi::on_starting([&](auto up) {
                   signals += 10;
@@ -362,8 +346,8 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
 
         // accumulate known signals
         ++total;
-        cancellostrace += signals == 110110;
-        cancelled += signals == 110011;
+        cancellostrace += signals == 10110;
+        cancelled += signals == 10011;
 
         if (total != cancellostrace + cancelled) {
           // display the unrecognized signals recorded
@@ -376,7 +360,7 @@ SCENARIO("flow single cancellation new thread", "[flow][deferred]") {
                        << ", cancelled " << cancelled);
           break;
         }
-        if (!!cancellostrace && !!cancelled) {
+        if (cancellostrace > 4 && cancelled > 4) {
           // yay all known outcomes were observed!
           break;
         }


### PR DESCRIPTION
I have cancellation working without the stopping signal, it is not needed and actually would cause problems with r-value qualified signals - error etc.. 