### PR TITLE
split up the tests into separate executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script: cmake
 env:
   global:
     - DEPS_DIR=${TRAVIS_BUILD_DIR}/deps
+    - CMAKE_VERSION="3.12.0"
 
 cache:
   directories:
@@ -155,7 +156,7 @@ before_install:
   - |
     if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
       if [ -z "$(ls -A ${DEPS_DIR}/cmake-${CMAKE_VERSION}/cached)" ]; then
-        CMAKE_URL="https://cmake.org/files/v3.6/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+        CMAKE_URL="https://cmake.org/files/v3.12/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
         mkdir -p ${DEPS_DIR}/cmake-${CMAKE_VERSION}
         travis_retry wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake-${CMAKE_VERSION}
         touch ${DEPS_DIR}/cmake-${CMAKE_VERSION}/cached

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,15 +16,13 @@ target_include_directories(pushmi INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/executors-impl/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/futures-impl/future-executor-interaction/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/networking-ts-impl/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/Catch2/single_include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/nonius/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/executors>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/futures>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/net>
-    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/Catch2>
-    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/nonius>)
-
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/nonius>
+)
 
 if (PUSHMI_USE_CONCEPTS_EMULATION)
 
@@ -65,7 +63,6 @@ target_compile_options(pushmi INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-fconcepts>)
 
 endif(PUSHMI_USE_CONCEPTS_EMULATION)
-
 
 target_compile_options(pushmi INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-ftemplate-backtrace-limit=0>)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,17 +1,24 @@
-
-
-add_executable(PushmiTest
-  catch.cpp
-  FlowTest.cpp
-  CompileTest.cpp
-  NewThreadTest.cpp
-  TrampolineTest.cpp
-  PushmiTest.cpp
-)
-target_link_libraries(PushmiTest
-  pushmi
-  Threads::Threads
-)
-
 include(../external/Catch2/contrib/Catch.cmake)
+
+add_library(CatchImpl catch.cpp)
+target_link_libraries(CatchImpl pushmi)
+
+add_executable(FlowTest FlowTest.cpp)
+target_link_libraries(FlowTest pushmi CatchImpl Threads::Threads)
+catch_discover_tests(FlowTest)
+
+add_executable(CompileTest CompileTest.cpp)
+target_link_libraries(CompileTest pushmi CatchImpl Threads::Threads)
+# catch_discover_tests(CompileTest)
+
+add_executable(NewThreadTest NewThreadTest.cpp)
+target_link_libraries(NewThreadTest pushmi CatchImpl Threads::Threads)
+catch_discover_tests(NewThreadTest)
+
+add_executable(TrampolineTest TrampolineTest.cpp)
+target_link_libraries(TrampolineTest pushmi CatchImpl Threads::Threads)
+catch_discover_tests(TrampolineTest)
+
+add_executable(PushmiTest PushmiTest.cpp)
+target_link_libraries(PushmiTest pushmi CatchImpl Threads::Threads)
 catch_discover_tests(PushmiTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,26 @@
+add_library(catch STATIC catch.cpp)
+target_include_directories(catch PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/Catch2/single_include>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/Catch2>)
+
 include(../external/Catch2/contrib/Catch.cmake)
 
-add_library(CatchImpl catch.cpp)
-target_link_libraries(CatchImpl pushmi)
-
 add_executable(FlowTest FlowTest.cpp)
-target_link_libraries(FlowTest pushmi CatchImpl Threads::Threads)
+target_link_libraries(FlowTest pushmi catch Threads::Threads)
 catch_discover_tests(FlowTest)
 
 add_executable(CompileTest CompileTest.cpp)
-target_link_libraries(CompileTest pushmi CatchImpl Threads::Threads)
+target_link_libraries(CompileTest pushmi catch Threads::Threads)
 # catch_discover_tests(CompileTest)
 
 add_executable(NewThreadTest NewThreadTest.cpp)
-target_link_libraries(NewThreadTest pushmi CatchImpl Threads::Threads)
+target_link_libraries(NewThreadTest pushmi catch Threads::Threads)
 catch_discover_tests(NewThreadTest)
 
 add_executable(TrampolineTest TrampolineTest.cpp)
-target_link_libraries(TrampolineTest pushmi CatchImpl Threads::Threads)
+target_link_libraries(TrampolineTest pushmi catch Threads::Threads)
 catch_discover_tests(TrampolineTest)
 
 add_executable(PushmiTest PushmiTest.cpp)
-target_link_libraries(PushmiTest pushmi CatchImpl Threads::Threads)
+target_link_libraries(PushmiTest pushmi catch Threads::Threads)
 catch_discover_tests(PushmiTest)


### PR DESCRIPTION
Use `make test` to run all the tests.