### PR TITLE
Fix the foreach_2 example by waiting the threads' completion

### DIFF
--- a/examples/for_each/for_each_2.cpp
+++ b/examples/for_each/for_each_2.cpp
@@ -100,10 +100,10 @@ int main()
     x = 42;
   });
 
+  p.wait();
+  p.stop();
+
   assert(std::count(vec.begin(), vec.end(), 42) == static_cast<int>(vec.size()));
 
   std::cout << "OK" << std::endl;
-
-  p.stop();
-  p.wait();
 }


### PR DESCRIPTION
Fix the foreach_2 example by waiting the threads' completion before the check.

Before the update, the for_each_2 example was failing.