### PR TITLE
Remove explicit include for gtest for old CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,12 +149,5 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
 
-# The gtest/gtest_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
-  include_directories("${gtest_SOURCE_DIR}/include")
-endif()
-
 include(CTest)
 add_subdirectory(test)


### PR DESCRIPTION
Summary:
- For older versions of CMake -- specifically 2.8.11 or lower, you need
  to explicitly add the incldue directory for gtest.
- However, since `pushmi` requires CMake 3.7 or later, this does not
  need to be guarded against.